### PR TITLE
Analyzer/Checker draft

### DIFF
--- a/maltoolbox/language/lexer_parser/__main__.py
+++ b/maltoolbox/language/lexer_parser/__main__.py
@@ -3,7 +3,7 @@
 from antlr4 import FileStream, CommonTokenStream
 from .mal_lexer import malLexer
 from .mal_parser import malParser
-# from .mal_visitor import malVisitor
+from .mal_visitor import malVisitor
 from .mal_analyzer import malAnalyzer
 
 import sys
@@ -30,7 +30,8 @@ class MalCompiler:
         parser = malParser(stream)
         tree = parser.mal()
 
-        return malAnalyzer(compiler=self).visit(tree)
+        analyzer = malAnalyzer()
+        return malVisitor(compiler=self, analyzer=analyzer).visit(tree)
 
 
 if __name__ == "__main__":

--- a/maltoolbox/language/lexer_parser/__main__.py
+++ b/maltoolbox/language/lexer_parser/__main__.py
@@ -3,7 +3,8 @@
 from antlr4 import FileStream, CommonTokenStream
 from .mal_lexer import malLexer
 from .mal_parser import malParser
-from .mal_visitor import malVisitor
+# from .mal_visitor import malVisitor
+from .mal_analyzer import malAnalyzer
 
 import sys
 import os
@@ -29,7 +30,7 @@ class MalCompiler:
         parser = malParser(stream)
         tree = parser.mal()
 
-        return malVisitor(compiler=self).visit(tree)
+        return malAnalyzer(compiler=self).visit(tree)
 
 
 if __name__ == "__main__":

--- a/maltoolbox/language/lexer_parser/mal_analyzer.py
+++ b/maltoolbox/language/lexer_parser/mal_analyzer.py
@@ -1,0 +1,235 @@
+from antlr4 import ParseTreeVisitor
+from .mal_parser import malParser
+
+from dataclasses import dataclass
+import logging
+import re
+    
+class malAnalyzer(ParseTreeVisitor):
+    '''
+    A class to preform syntax-checks for MAL.
+    '''
+
+    class Analyze:
+        '''
+        A decoration to insert `super().<visit-method>(...)` in child.
+        If `malAnalyzer` haven't implemented that method an error message
+        will occur and a raise.
+        '''
+        def __init__(self, func):
+            self.func = func
+
+        def __get__(self, instance, owner):
+            def wrapper(*args, **kwargs):
+                super_method = getattr(super(owner, instance), self.func.__name__, None)
+                # Check if method is implemented.
+                if super_method:
+                    super_method(*args, **kwargs)
+                else:
+                    logging.error(f'There is no analyzer implemented for \'{self.func.__name__}\'')
+                    raise
+
+                return self.func(instance, *args, **kwargs)
+            return wrapper
+        
+    @dataclass
+    class ContextWrapper():
+        '''
+        A wrapper to store context 
+        for post-analysis.
+        '''
+        name: str
+        ctx: any
+        def __str__(self) -> str:
+            return self.name
+    
+    @dataclass
+    class AssetWrapper(ContextWrapper):
+        '''
+        A wrapper to store assets.
+        '''
+        attack_steps: [malParser.StepContext]
+        
+    def __init__(self, *args, **kwargs) -> None:
+        self._error:   bool = False
+        self._defines: dict[str, self.ContextWrapper] = {}
+        self._assets:  dict[str, self.AssetWrapper  ] = {}
+        self._metas:   dict[str, self.ContextWrapper] = {}
+
+        super().__init__(*args, **kwargs)
+
+    def visit(self, ctx: malParser.MalContext) -> any:
+        '''
+        Override ParseTreeVisitor `visit` to be able
+        to preform `__post_analysis` as last step.
+        '''
+        result: any = super().visit(ctx)
+        if ctx.depth() == 1:
+            self.__post_analysis()
+        return result
+
+    def is_valid(self) -> bool:
+        return self._error
+
+    def __post_analysis(self) -> None:
+        '''
+        Perform a post-analysis to confirm that the 
+        mandatory fields and relations are met.
+        '''
+        self.__analyse_defines()
+        self.__analyse_extends()
+        self.__analyse_abstract()
+        self.__analyse_parents()
+        self.__analyse_steps()
+
+    
+    def __analyse_defines(self) -> None:
+        '''
+        Check for mandatory defines: ID & Version
+        '''
+
+        if 'id' in  self._defines:
+            value: str = self._defines['id'].ctx.STRING().getText()[1:-1]
+            if(len(value.strip()) == 0):
+                logging.error('Define \'id\' cannot be empty')
+                self._error = True
+        else:
+            logging.error('Missing required define \'#id: ""\'')
+            self._error = True
+
+        if 'version' in self._defines:
+            version: str = self._defines['version'].ctx.STRING().getText()[1:-1]
+            if not re.match(r"\d+\.\d+\.\d+", version):
+                logging.error(f'Define \'version\' must be valid semantic versioning without pre-release identifier and build metadata')
+                self._error = True
+        else:
+            logging.error('Missing required define \'#version: ""\'')
+            self._error = True
+
+    def __analyse_extends(self) -> None:
+        raise_error: bool = False
+        extend_asset_name: str = ''
+        for asset in self._assets:
+            asset_context: malParser.AssetContext = self._assets[asset].ctx
+            if(asset_context.EXTENDS()):
+                extend_asset_name = asset_context.getChild(3).getText()
+                if(not extend_asset_name in self._assets):
+                    '''
+                    Do we need to check if the extended asset is 
+                    in the same category? If so we can load the asset
+                    and check it's parent
+                    '''
+                    logging.error(f'Asset \'{extend_asset_name}\' not defined')
+                    raise_error = True
+        if raise_error:
+            self._error = True   # Maybe unnecessary if we raise
+            raise SyntaxError(f'Asset \'{extend_asset_name}\' not defined')
+
+    def __analyse_abstract(self) -> None:
+        for parent in self._assets:
+            parent_ctx: malParser.AssetContext = self._assets[parent].ctx
+            print(parent_ctx.ID()[0].getText())
+            if(parent_ctx.ABSTRACT()):
+                found: bool = False
+                for extendee in self._assets:
+                    '''
+                    Add same parent check?
+                    '''
+                    extendee_ctx: malParser.AssetContext = self._assets[extendee].ctx
+                    if(extendee_ctx.EXTENDS() and extendee_ctx.ID()[1].getText() == parent_ctx.ID()[0].getText()):
+                        found = True
+                        break
+                if not found:
+                    logging.warn(f'Asset \'{parent_ctx.ID()[0].getText()}\' is abstract but never extended to')
+    
+    def __analyse_parents(self) -> None:
+        error: bool = False
+        for asset in self._assets:
+            parents: list[str] = []
+            parent_ctx: malParser.AssetContext  = self._assets[asset].ctx
+            while (isinstance(parent_ctx, malParser.AssetContext)):
+                parent_name: str = parent_ctx.ID()[0].getText()
+                if (parent_name in parents):
+                    err_msg: str = ' -> '.join(parents)
+                    err_msg += f' -> {parent_name}' 
+                    logging.error(f'Asset \'{parent_name}\' extends in loop \'{err_msg}\'')
+                    error = True
+                    break
+                parents.append(parent_name)
+                parent_ctx = self.__get_assets_extendee(parent_ctx)
+        if error:
+            self._error = True
+            raise
+    
+    def __analyse_steps(self):
+        logging.warning('__analyse_steps not implemented.')
+        # for asset in self._assets:
+        #     pass
+
+    def __get_assets_extendee(self, ctx: malParser.AssetContext) -> malParser.AssetContext:
+        if (ctx.EXTENDS()):
+            return self._assets[ctx.ID()[1].getText()].ctx
+        return None
+
+    def visitDefine(self, ctx: malParser.DefineContext) -> None:
+        define_id: str = ctx.ID().getText()
+
+        # Check if define was previously defined.
+        if define_id in self._defines:
+            prevDef = self._defines[define_id].ctx.start.line
+            logging.error(f'Define \'{define_id}\' previously defined at {prevDef}')
+            self._error = True
+            return
+        
+        self._defines[define_id] = self.ContextWrapper(ctx=ctx, name=define_id)  
+
+    def visitCategory(self, ctx: malParser.CategoryContext) -> None:
+        category_name: str = ctx.ID().getText()
+        if (len(ctx.asset()) == 0 and len(ctx.meta()) == 0):
+            logging.error(f'Category \'{category_name}\' contains no assets or metadata')
+            self._error = True
+            return
+        
+    def visitAsset(self, ctx: malParser.AssetContext) -> None:
+        asset_id: str = ctx.ID()[0].getText()
+
+        '''
+        # Is this possible to check?
+        category: malParser.CategoryContext = ctx.parentCtx
+        if not category: 
+            logging.error(f'Asset \'{asset_id}\' is outside an category')
+        '''
+
+        # Check if asset was previously defined.
+        if asset_id in self._assets:
+            prevDef = self._assets[asset_id].ctx.start.line
+            logging.error(f"Asset '{asset_id}' previously defined at {prevDef}")
+            self._error = True
+            return
+        else:
+            self._assets[asset_id] = self.AssetWrapper(ctx=ctx, name=asset_id, attack_steps=[]) 
+
+    def visitMeta(self, ctx: malParser.MetaContext) -> None:
+        meta_id: str = ctx.ID().getText()
+      
+        # Check if meta was previously defined.
+        if meta_id in self._metas:
+            prevDef = self._metas[meta_id].ctx.start.line
+            logging.error(f"Metadata '{meta_id}' previously defined at {prevDef}")
+            self._error = True
+            return
+        else:
+            self._metas[meta_id] = self.ContextWrapper(ctx=ctx, name=meta_id) 
+
+    def visitStep(self, ctx: malParser.StepContext) -> None:
+        logging.warn('visitStep not implemented.')
+        # step_id: str = ctx.ID().getText()
+        # parent_asset_name = ctx.parentCtx.ID()[0].getText()
+        # if  parent_asset_name in self._assets:
+        #     logging.error(f'Asset \'{parent_asset_name}\' was not found.')
+        #     self._error = True
+        #     return
+        
+        # parent_asset: self.AssetWrapper = self._assets[parent_asset_name]
+        # Can a step be define twice?
+        # parent_asset.attack_steps.append(ctx)  

--- a/maltoolbox/language/lexer_parser/mal_analyzer.py
+++ b/maltoolbox/language/lexer_parser/mal_analyzer.py
@@ -1,72 +1,22 @@
-from antlr4 import ParseTreeVisitor
 from .mal_parser import malParser
+from .mal_visitor import malVisitor
 
-from dataclasses import dataclass
 import logging
 import re
     
-class malAnalyzer(ParseTreeVisitor):
+class malAnalyzer(malVisitor):
     '''
     A class to preform syntax-checks for MAL.
     '''
-
-    class Analyze:
-        '''
-        A decoration to insert `super().<visit-method>(...)` in child.
-        If `malAnalyzer` haven't implemented that method an error message
-        will occur and a raise.
-        '''
-        def __init__(self, func):
-            self.func = func
-
-        def __get__(self, instance, owner):
-            def wrapper(*args, **kwargs):
-                super_method = getattr(super(owner, instance), self.func.__name__, None)
-                # Check if method is implemented.
-                if super_method:
-                    super_method(*args, **kwargs)
-                else:
-                    logging.error(f'There is no analyzer implemented for \'{self.func.__name__}\'')
-                    raise
-
-                return self.func(instance, *args, **kwargs)
-            return wrapper
-        
-    @dataclass
-    class ContextWrapper():
-        '''
-        A wrapper to store context 
-        for post-analysis.
-        '''
-        name: str
-        ctx: any
-        def __str__(self) -> str:
-            return self.name
-    
-    @dataclass
-    class AssetWrapper(ContextWrapper):
-        '''
-        A wrapper to store assets.
-        '''
-        attack_steps: [malParser.StepContext]
         
     def __init__(self, *args, **kwargs) -> None:
         self._error:   bool = False
-        self._defines: dict[str, self.ContextWrapper] = {}
-        self._assets:  dict[str, self.AssetWrapper  ] = {}
-        self._metas:   dict[str, self.ContextWrapper] = {}
-
+        self._defines: dict = {}
+        self._assets: dict = {}
+        self._category: dict = {}
+        self._metas: dict = {}
+        self._steps: dict = {}
         super().__init__(*args, **kwargs)
-
-    def visit(self, ctx: malParser.MalContext) -> any:
-        '''
-        Override ParseTreeVisitor `visit` to be able
-        to preform `__post_analysis` as last step.
-        '''
-        result: any = super().visit(ctx)
-        if ctx.depth() == 1:
-            self.__post_analysis()
-        return result
 
     def is_valid(self) -> bool:
         return self._error
@@ -80,17 +30,15 @@ class malAnalyzer(ParseTreeVisitor):
         self.__analyse_extends()
         self.__analyse_abstract()
         self.__analyse_parents()
-        self.__analyse_steps()
-
     
     def __analyse_defines(self) -> None:
         '''
         Check for mandatory defines: ID & Version
         '''
 
-        if 'id' in  self._defines:
-            value: str = self._defines['id'].ctx.STRING().getText()[1:-1]
-            if(len(value.strip()) == 0):
+        if 'id' in  self._defines.keys():
+            define_value: str = self._defines['id']['obj']['id']
+            if(len(define_value) == 0):
                 logging.error('Define \'id\' cannot be empty')
                 self._error = True
         else:
@@ -98,7 +46,7 @@ class malAnalyzer(ParseTreeVisitor):
             self._error = True
 
         if 'version' in self._defines:
-            version: str = self._defines['version'].ctx.STRING().getText()[1:-1]
+            version: str = self._defines['version']['obj']['version']
             if not re.match(r"\d+\.\d+\.\d+", version):
                 logging.error(f'Define \'version\' must be valid semantic versioning without pre-release identifier and build metadata')
                 self._error = True
@@ -110,9 +58,9 @@ class malAnalyzer(ParseTreeVisitor):
         raise_error: bool = False
         extend_asset_name: str = ''
         for asset in self._assets:
-            asset_context: malParser.AssetContext = self._assets[asset].ctx
+            asset_context: malParser.AssetContext = self._assets[asset]['ctx']
             if(asset_context.EXTENDS()):
-                extend_asset_name = asset_context.getChild(3).getText()
+                extend_asset_name = asset_context.ID()[1].getText()
                 if(not extend_asset_name in self._assets):
                     '''
                     Do we need to check if the extended asset is 
@@ -127,15 +75,14 @@ class malAnalyzer(ParseTreeVisitor):
 
     def __analyse_abstract(self) -> None:
         for parent in self._assets:
-            parent_ctx: malParser.AssetContext = self._assets[parent].ctx
-            print(parent_ctx.ID()[0].getText())
+            parent_ctx: malParser.AssetContext = self._assets[parent]['ctx']
             if(parent_ctx.ABSTRACT()):
                 found: bool = False
                 for extendee in self._assets:
                     '''
                     Add same parent check?
                     '''
-                    extendee_ctx: malParser.AssetContext = self._assets[extendee].ctx
+                    extendee_ctx: malParser.AssetContext = self._assets[extendee]['ctx']
                     if(extendee_ctx.EXTENDS() and extendee_ctx.ID()[1].getText() == parent_ctx.ID()[0].getText()):
                         found = True
                         break
@@ -146,7 +93,7 @@ class malAnalyzer(ParseTreeVisitor):
         error: bool = False
         for asset in self._assets:
             parents: list[str] = []
-            parent_ctx: malParser.AssetContext  = self._assets[asset].ctx
+            parent_ctx: malParser.AssetContext  = self._assets[asset]['ctx']
             while (isinstance(parent_ctx, malParser.AssetContext)):
                 parent_name: str = parent_ctx.ID()[0].getText()
                 if (parent_name in parents):
@@ -161,75 +108,157 @@ class malAnalyzer(ParseTreeVisitor):
             self._error = True
             raise
     
-    def __analyse_steps(self):
-        logging.warning('__analyse_steps not implemented.')
-        # for asset in self._assets:
-        #     pass
-
     def __get_assets_extendee(self, ctx: malParser.AssetContext) -> malParser.AssetContext:
         if (ctx.EXTENDS()):
-            return self._assets[ctx.ID()[1].getText()].ctx
+            return self._assets[ctx.ID()[1].getText()]['ctx']
         return None
+    
+    def visitMal(self, ctx: malParser.MalContext) -> None:
+        result = super().visitMal(ctx)
+        self.__post_analysis()
+        return result
 
     def visitDefine(self, ctx: malParser.DefineContext) -> None:
-        define_id: str = ctx.ID().getText()
+        result = super().visitDefine(ctx)
+        [_, obj] = result
 
-        # Check if define was previously defined.
-        if define_id in self._defines:
-            prevDef = self._defines[define_id].ctx.start.line
-            logging.error(f'Define \'{define_id}\' previously defined at {prevDef}')
-            self._error = True
-            return
+        if(len(obj.keys()) != 1):
+            raise 
         
-        self._defines[define_id] = self.ContextWrapper(ctx=ctx, name=define_id)  
-
-    def visitCategory(self, ctx: malParser.CategoryContext) -> None:
-        category_name: str = ctx.ID().getText()
-        if (len(ctx.asset()) == 0 and len(ctx.meta()) == 0):
-            logging.error(f'Category \'{category_name}\' contains no assets or metadata')
+        define_id = next(iter(obj))
+        if(define_id in self._defines.keys()):
+            prev_define_line = self._defines[define_id]['ctx'].start.line
+            logging.error(f'Define \'{define_id}\' previously defined at line {prev_define_line}')
             self._error = True
-            return
+            return result
+        
+        self._defines[define_id] = {'ctx': ctx, 'obj': obj}
+        return result
+    
+    def visitCategory(self, ctx: malParser.CategoryContext) -> None:
+        result = super().visitCategory(ctx)
+
+        category = result[1][0][0]
+        if(category['name'] == '<missing <INVALID>>'):
+            category_line = ctx.start.line
+            logging.error(f'Category has no name at line {category_line}')
+            self._error = True
+            return result
+
+        if len(category['meta']) == 0 and len(result[1][1]) == 0:
+            logging.warning(f'Category \'{category["name"]}\' contains no assets or metadata')
+            self._error = True
+            return result
+        
+        self._category[category['name']] = {'ctx': ctx, 'obj': result}
+        
+        return result
         
     def visitAsset(self, ctx: malParser.AssetContext) -> None:
-        asset_id: str = ctx.ID()[0].getText()
+        result = super().visitAsset(ctx)
+        asset_name = result['name']
+        category_name = ctx.parentCtx.ID()
 
-        '''
-        # Is this possible to check?
-        category: malParser.CategoryContext = ctx.parentCtx
-        if not category: 
-            logging.error(f'Asset \'{asset_id}\' is outside an category')
-        '''
-
-        # Check if asset was previously defined.
-        if asset_id in self._assets:
-            prevDef = self._assets[asset_id].ctx.start.line
-            logging.error(f"Asset '{asset_id}' previously defined at {prevDef}")
+        # Check if asset was previously defined in same category.
+        if asset_name in self._assets.keys() and self._assets[asset_name]['parent']['name'] == category_name:
+            prev_asset_line = self._assets[asset_name]['ctx'].start.line
+            logging.error(f"Asset '{asset_name}' previously defined at {prev_asset_line}")
             self._error = True
-            return
+            return result
         else:
-            self._assets[asset_id] = self.AssetWrapper(ctx=ctx, name=asset_id, attack_steps=[]) 
+            self._assets[asset_name] = {'ctx': ctx, 'obj': result, 'parent': {'name': ctx.parentCtx.ID() ,'ctx': ctx.parentCtx}}
+        return result
 
     def visitMeta(self, ctx: malParser.MetaContext) -> None:
-        meta_id: str = ctx.ID().getText()
-      
-        # Check if meta was previously defined.
-        if meta_id in self._metas:
-            prevDef = self._metas[meta_id].ctx.start.line
-            logging.error(f"Metadata '{meta_id}' previously defined at {prevDef}")
+        result = super().visitMeta(ctx)
+        meta_name = result[0][0]
+        parent_name = ''
+        location_name = ''
+
+        # Finding metadata type
+        if isinstance(ctx.parentCtx, malParser.CategoryContext):
+            parent_name = ctx.parentCtx.ID()
+            location_name = 'category'
+        elif isinstance(ctx.parentCtx, malParser.AssetContext):
+            parent_name = ctx.parentCtx.ID()[0]
+            location_name = 'asset'
+        elif isinstance(ctx.parentCtx, malParser.StepContext):
+            parent_name = ctx.parentCtx.ID()
+            location_name = 'step'
+        
+        # Validate that the metadata is unique
+        if not location_name in self._metas.keys():
+            self._metas[location_name] = {parent_name: {meta_name: ctx}}
+        elif not parent_name in self._metas[location_name].keys():
+            self._metas[location_name][parent_name] = {meta_name: ctx}
+        elif not meta_name in self._metas[location_name][parent_name].keys():
+            self._metas[location_name][parent_name][meta_name] = ctx
+        else:
+            prev_ctx = self._metas[location_name][parent_name][meta_name]
+            logging.error(f'Metadata {meta_name} previously defined at {prev_ctx.start.line}')
+            self._error = True
+
+        # TODO: check for Associations
+            
+        return result
+
+
+    def visitStep(self, ctx: malParser.StepContext):
+        step = super().visitStep(ctx)
+        step_name = step['name']
+
+        if isinstance(ctx.parentCtx, malParser.AssetContext):
+            asset_name = ctx.parentCtx.ID()[0]   
+
+            # TODO: Validate step
+            # if (not asset_name in self._steps.keys()):
+            #     self._steps[asset_name] = {step_name: ctx}
+            self._validate_CIA(ctx, step)
+            self._validate_TTC(ctx, step)
+
+        return step
+    
+    def _validate_TTC(self, ctx: malParser.StepContext, step):
+        if not step['ttc']:
+            return
+        
+        if step['type'] == 'defense':
+            # TODO: TTCFuncExpr
+            # if !(ttc instanceof AST.TTCFuncExpr)
+            #      error
+            # elif fname = Enabled, Disabled, Bernoulli
+            #   Distributions.validate(fname, fparams);
+            # else 
+            #    ERROR   Defense %s.%s may only have 'Enabled', 'Disabled', or 'Bernoulli(p)' as TTC"
+            pass
+
+    def visitTtcexpr(self, ctx: malParser.TtcexprContext):
+       pass
+
+    def _validate_CIA(self, ctx: malParser.StepContext, step):
+        if not ctx.cias():
+            return
+        
+        step_name = step['name']
+        asset_name = ctx.parentCtx.ID()[0] 
+
+        if (step['type'] == 'defense' or step['type'] == 'exist' or step['type'] == 'notExist'):
+            logging.error(f'{step_name}: Defenses cannot have CIA classifications')
             self._error = True
             return
-        else:
-            self._metas[meta_id] = self.ContextWrapper(ctx=ctx, name=meta_id) 
 
-    def visitStep(self, ctx: malParser.StepContext) -> None:
-        logging.warn('visitStep not implemented.')
-        # step_id: str = ctx.ID().getText()
-        # parent_asset_name = ctx.parentCtx.ID()[0].getText()
-        # if  parent_asset_name in self._assets:
-        #     logging.error(f'Asset \'{parent_asset_name}\' was not found.')
-        #     self._error = True
-        #     return
-        
-        # parent_asset: self.AssetWrapper = self._assets[parent_asset_name]
-        # Can a step be define twice?
-        # parent_asset.attack_steps.append(ctx)  
+        index = 0
+        cias = []
+        while cia := ctx.cias().getChild(index):
+            if(isinstance(cia, malParser.CiaContext)):
+                letter = ''
+                letter = 'C' if cia.C() else letter
+                letter = 'I' if cia.I() else letter
+                letter = 'A' if cia.A() else letter
+                
+                if (letter in cias):
+                    logging.error(f'Attack step {asset_name}.{step_name} contains duplicate classification {letter}')
+                    self._error = True
+                    return
+                cias.append(letter)
+            index += 1

--- a/maltoolbox/language/lexer_parser/mal_visitor.py
+++ b/maltoolbox/language/lexer_parser/mal_visitor.py
@@ -1,6 +1,6 @@
-from antlr4 import ParseTreeVisitor
 
 from .mal_parser import malParser
+from .mal_analyzer import malAnalyzer
 
 from collections.abc import MutableMapping, MutableSequence
 
@@ -9,7 +9,7 @@ from collections.abc import MutableMapping, MutableSequence
 #   - ctx.two() would be []
 
 
-class malVisitor(ParseTreeVisitor):
+class malVisitor(malAnalyzer):
     def __init__(self, compiler, *args, **kwargs):
         self.compiler = compiler
         self.current_file = compiler.current_file  # for debug purposes
@@ -61,10 +61,12 @@ class malVisitor(ParseTreeVisitor):
 
     def visitInclude(self, ctx):
         return ("include", ctx.STRING().getText().strip('"'))
-
+    
+    @malAnalyzer.Analyze
     def visitDefine(self, ctx):
         return ("defines", {ctx.ID().getText(): ctx.STRING().getText().strip('"')})
 
+    @malAnalyzer.Analyze
     def visitCategory(self, ctx):
         category = {}
         category["name"] = ctx.ID().getText()
@@ -74,9 +76,11 @@ class malVisitor(ParseTreeVisitor):
 
         return ("categories", ([category], assets))
 
+    @malAnalyzer.Analyze
     def visitMeta(self, ctx):
         return ((ctx.ID().getText(), ctx.STRING().getText().strip('"')),)
 
+    @malAnalyzer.Analyze
     def visitAsset(self, ctx):
         asset = {}
         asset["name"] = ctx.ID()[0].getText()
@@ -92,7 +96,8 @@ class malVisitor(ParseTreeVisitor):
         asset["attackSteps"] = [self.visit(step) for step in ctx.step()]
 
         return asset
-
+    
+    @malAnalyzer.Analyze
     def visitStep(self, ctx):
         step = {}
         step["name"] = ctx.ID().getText()

--- a/maltoolbox/language/lexer_parser/mal_visitor.py
+++ b/maltoolbox/language/lexer_parser/mal_visitor.py
@@ -1,15 +1,16 @@
 
 from .mal_parser import malParser
-from .mal_analyzer import malAnalyzer
 
+from antlr4 import ParseTreeVisitor
 from collections.abc import MutableMapping, MutableSequence
+
 
 # In a rule like `rule: one? two* three`:
 #   - ctx.one() would be None if the token was not found on a matching line
 #   - ctx.two() would be []
 
 
-class malVisitor(malAnalyzer):
+class malVisitor(ParseTreeVisitor):
     def __init__(self, compiler, *args, **kwargs):
         self.compiler = compiler
         self.current_file = compiler.current_file  # for debug purposes
@@ -62,11 +63,9 @@ class malVisitor(malAnalyzer):
     def visitInclude(self, ctx):
         return ("include", ctx.STRING().getText().strip('"'))
     
-    @malAnalyzer.Analyze
     def visitDefine(self, ctx):
         return ("defines", {ctx.ID().getText(): ctx.STRING().getText().strip('"')})
 
-    @malAnalyzer.Analyze
     def visitCategory(self, ctx):
         category = {}
         category["name"] = ctx.ID().getText()
@@ -76,11 +75,9 @@ class malVisitor(malAnalyzer):
 
         return ("categories", ([category], assets))
 
-    @malAnalyzer.Analyze
     def visitMeta(self, ctx):
         return ((ctx.ID().getText(), ctx.STRING().getText().strip('"')),)
 
-    @malAnalyzer.Analyze
     def visitAsset(self, ctx):
         asset = {}
         asset["name"] = ctx.ID()[0].getText()
@@ -97,7 +94,6 @@ class malVisitor(malAnalyzer):
 
         return asset
     
-    @malAnalyzer.Analyze
     def visitStep(self, ctx):
         step = {}
         step["name"] = ctx.ID().getText()

--- a/maltoolbox/language/tests/test_mal_analyzer.py
+++ b/maltoolbox/language/tests/test_mal_analyzer.py
@@ -1,0 +1,422 @@
+import pytest
+
+from antlr4 import InputStream, CommonTokenStream
+from lexer_parser.mal_lexer import malLexer
+from lexer_parser.mal_parser import malParser
+from lexer_parser.mal_visitor import malVisitor
+from lexer_parser.mal_analyzer import malAnalyzer
+
+class MockCompiler():
+    def __init__(self):
+        self.path = None
+        self.current_file = None
+
+def compile_text(analyzer: malAnalyzer, input_string: str):
+    '''
+    A function to test the compiler flow with data from a string.
+    '''
+    input_stream = InputStream(input_string)
+    lexer = malLexer(input_stream)
+    stream = CommonTokenStream(lexer)
+    parser = malParser(stream)
+    tree = parser.mal()
+    compiler = MockCompiler()
+    return malVisitor(compiler=compiler,  analyzer=analyzer).visit(tree)
+
+def test_construct():
+    analyzer = malAnalyzer()
+    assert analyzer.has_error() == False
+
+def test_full_flow_empty():
+    analyzer = malAnalyzer()
+    result = compile_text(analyzer, "")
+    assert analyzer.has_error() == True
+
+def test_full_flow_missing_define_id():
+    analyzer = malAnalyzer()
+    input = """
+    #version:"0.0.0"
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+    defines = list(analyzer._defines.keys())
+    assert defines == ['version']
+
+def test_full_flow_missing_define_version():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+    defines = list(analyzer._defines.keys())
+    assert defines == ['id']
+
+def test_full_flow_wrong_format_version():
+    '''
+    The analyzer will add 'version' to the define-dict,
+    but will fail during the post-analyzer stage.
+    '''
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"version1"
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+    defines = list(analyzer._defines.keys())
+    assert defines == ['id', 'version']
+
+def test_full_flow_correct_require_defines():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == False
+    defines = list(analyzer._defines.keys())
+    assert defines == ['id', 'version']
+
+def test_full_flow_prev_def_defines():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+    #version:"1.0.0"
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+    defines = list(analyzer._defines.keys())
+    assert defines == ['id', 'version']
+
+def test_full_flow_category_missing_name():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category {
+
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_correct_category():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System {
+
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == False
+
+def test_full_flow_prev_def_asset_1():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System {
+        asset Test {}
+        asset Test {}
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_prev_def_asset_2():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System {asset Test {}}
+    category System {asset Test {}}
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+    defines = list(analyzer._defines.keys())
+    assert defines == ['id', 'version']
+
+def test_full_flow_correct_asset():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System { 
+        asset Test {
+        
+        }
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == False
+
+def test_full_flow_prev_def_category_meta_1():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System 
+    User: "Owner"
+    User: "Borrow"
+    {}
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_prev_def_category_meta_2():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System 
+      User: "Owner"
+    {}
+    category System 
+      User: "Borrow"
+    {}
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_prev_def_asset_meta_1():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System 
+    {
+        asset Test 
+          User: "Owner"
+          User: "Borrow" 
+        {}
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_prev_def_asset_meta_1():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System 
+    {
+        asset Test 
+          User: "Borrow" 
+        {}
+    }
+
+    category System 
+    {
+        asset Test 
+          User: "Owner"
+        {}
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+
+def test_full_flow_prev_def_asset_meta_1():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System 
+    {
+        asset Test 
+        {
+        | Attack
+          User: "Attacking"
+          User: "Looking"
+        }
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_ok_meta():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System
+      User: "Owner" 
+    {
+        asset Network 
+          User: "Owner"
+        {
+        | Attack
+          User: "Attacking" 
+        }
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == False
+
+def test_full_flow_extends():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+    
+    category Systems {
+      asset Foo1 extends Foo2 {}
+    }
+    """
+    with pytest.raises(SyntaxError):
+        result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_circular_dependency():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+    
+    // Test Circular Dependency
+    category Systems {
+      asset Foo1 extends Foo2 {}
+      asset Foo2 extends Foo3 {}
+      asset Foo3 extends Foo4 {}
+      asset Foo4 extends Foo5 {}
+      asset Foo5 extends Foo1 {}
+    }
+    """
+    with pytest.raises(Exception):
+        result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_CIA_fail():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+    
+    category Systems {
+        asset CIA_TEST 
+        {
+        | readOnly {C}
+        | readAndAppend {C, I, I}
+        | fullAccess {C, I, A}
+        } 
+    } 
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_CIA_defense_fail():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+    
+    category Systems {
+        asset CIA_TEST 
+        {
+        # readOnly {C}
+        } 
+    } 
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+
+def test_full_flow_CIA_OK():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+    
+    category Systems {
+        asset CIA_TEST 
+        {
+        | readOnly {C}
+        | readAndAppend {C, I}
+        | fullAccess {C, I, A}
+        } 
+    } 
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == False
+
+def test_full_flow_var_1():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System {
+        asset Computer {
+            let components = hardware
+        }
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == False
+
+def test_full_flow_var_2():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System {
+        asset Computer {
+            let components = hardware
+            let components = software
+        }
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_var_2():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System {
+        asset Computer {
+            let components = hardware
+        }
+    }
+    category System {
+        asset Computer {
+            let components = software
+        }
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == True
+
+def test_full_flow_var_3():
+    analyzer = malAnalyzer()
+    input = """
+    #id: "org.mal-lang.testAnalyzer"
+    #version:"0.0.0"
+
+    category System {
+        asset Computer {
+            let components = software \\/ hardware
+        }
+    }
+    """
+    result = compile_text(analyzer, input)
+    assert analyzer.has_error() == False


### PR DESCRIPTION
# Analyzer/Checker draft

This is a draft for the analyzer/checker described in issue #6   
Only some of the checks are implemented into this version. 

## Implementation
The analyzer is a parent to the compiler `mal_visitor.py`.   
For every visit state we define inside `mal_visitor.py`, we also define inside `mal_analyzer.py` (if we want to check it). We can then access the `mal_analyzer.py` visit-method via super(...).
To make the code more readable there is a `decoration`  class inside `malAnalyzer` that will implement the super(...) code into the original visit method and also trigger an error if the method isn't defined inside `mal_analyzer.py `.

`ParseTreeVisitor` method `visit` is overridden in order to preform a `post-analysis` as the last step. `post-analysis` is for checks where we need to iterate all the assets or similar collections of data. By using the visit method to trigger `post-analysis` we don't need to change how the compiler is used. 

With this implementation it is very easy to add new rules to analyze/check and the core compiler only needs to add one line of code for every new `visitor` that should be checked.

## Naming

- Use the name `analyzer` or `checker`?
- Call the last step `post-analysis`?

## Potential issues / changes

- The `visit` method in `mal_analyser` is doing more then the method is meant to do, which can lead to confusion.
- The `Analyze` decoration can be removed in order to use super(...).visit(...) instead. Downside is no warnings for non-existing super methods.
- Don't have `malAnalyzer ` as parent to `malVisitor`, we could make `malAnalyzer` as a "normal" class and then preform calls in every visit function instead. 
- Some of the methods should be refactored.


