### PR TITLE
Fixes subType expression parsing

### DIFF
--- a/maltoolbox/__init__.py
+++ b/maltoolbox/__init__.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-# MAL Toolbox v0.1.1
+# MAL Toolbox v0.1.2
 # Copyright 2024, Andrei Buhaiu.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,7 @@ MAL-Toolbox Framework
 """
 
 __title__ = 'maltoolbox'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __authors__ = ['Andrei Buhaiu',
     'Giuseppe Nebbione',
     'Nikolaos Kakouros',

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from .node import AttackGraphNode
 from .attacker import Attacker
 from ..exceptions import AttackGraphStepExpressionError
-from ..language import specification
+from ..language import LanguageGraph
 from ..model import Model
 from ..exceptions import AttackGraphException
 from ..file_utils import (
@@ -150,11 +150,17 @@ def _process_step_expression(
                     step_expression['stepExpression'])
                 new_target_assets.extend(assets)
 
-            selected_new_target_assets = [asset for asset in \
-                new_target_assets if specification.extends_asset(
-                    lang_graph._lang_spec,
-                    asset.type,
-                    step_expression['subType'])]
+            subtype_asset = [
+                asset
+                for asset in lang_graph.assets
+                if asset.name == step_expression['subType']
+            ].pop()
+
+            selected_new_target_assets = (
+                asset
+                for asset in new_target_assets
+                if subtype_asset.is_subasset_of(asset)
+            )
             return (selected_new_target_assets, None)
 
         case 'collect':

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -156,11 +156,11 @@ def _process_step_expression(
                 if asset.name == step_expression['subType']
             ].pop()
 
-            selected_new_target_assets = (
+            selected_new_target_assets = [
                 asset
                 for asset in new_target_assets
                 if subtype_asset.is_subasset_of(asset)
-            )
+            ]
             return (selected_new_target_assets, None)
 
         case 'collect':

--- a/maltoolbox/model.py
+++ b/maltoolbox/model.py
@@ -104,7 +104,8 @@ class Model():
         self.asset_names.add(asset.name)
 
         # Optional field for extra asset data
-        asset.extras = {}
+        if not hasattr(asset, 'extras'):
+            asset.extras = {}
 
         logger.debug(
             'Add "%s"(%d) to model "%s".', asset.name, asset.id, self.name
@@ -691,6 +692,9 @@ class Model():
             asset = getattr(model.lang_classes_factory.ns,
                 asset_object['type'])(name = asset_object['name'])
 
+            if 'extras' in asset_object:
+                asset.extras = asset_object['extras']
+
             for defense in (defenses:=asset_object.get('defenses', [])):
                 setattr(asset, defense, float(defenses[defense]))
 
@@ -709,6 +713,9 @@ class Model():
                     field,
                     [model.get_asset_by_id(int(id)) for id in targets]
                 )
+
+            #TODO Properly handle extras
+
             model.add_association(association)
 
         # Reconstruct the attackers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mal-toolbox"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Andrei Buhaiu", email="buhaiu@kth.se" },
   { name="Giuseppe Nebbione", email="nebbione@kth.se" },

--- a/tests/attackgraph/test_node.py
+++ b/tests/attackgraph/test_node.py
@@ -5,7 +5,7 @@ from maltoolbox.attackgraph.attacker import Attacker
 from maltoolbox.attackgraph.attackgraph import AttackGraph
 
 def test_attackgraphnode():
-    """Create a graph from nodes
+    r"""Create a graph from nodes
 
             node1
             /    \


### PR DESCRIPTION
The `specification.extends_asset` method is expecting asset names as input while the attack graph uses LanguageGraphAsset objects. 

If this gets merged, `specification.extends_asset` will be used only in securicad.py which is outdated anyway.