### PR TITLE
Add `extras` field to Model assets/assocations and AttackGraphNodes

### DIFF
--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -160,7 +160,6 @@ def _process_step_expression(lang_graph: LanguageGraph, model: Model,
                 f'{step_expression["type"]}')
             return ([], None)
 
-
 class AttackGraph():
     """Graph representation of attack steps"""
     def __init__(self, lang_graph = None, model: Optional[Model] = None):

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -216,8 +216,6 @@ class AttackGraph():
                 'mitre_info' in node_dict else None
             ag_node.tags = node_dict['tags'] if \
                 'tags' in node_dict else []
-            ag_node.reward = float(node_dict['reward']) if \
-                'reward' in node_dict else 0.0
 
             if ag_node.name == 'firstSteps':
                 # This is an attacker entry point node, recreate the attacker.

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -24,7 +24,6 @@ class AttackGraphNode:
     extra: Optional[dict] = None
     mitre_info: Optional[str] = None
     tags: Optional[list[str]] = None
-    observations: Optional[dict] = None
     attributes: Optional[dict] = None
     attacker: Optional['Attacker'] = None
 
@@ -55,10 +54,6 @@ class AttackGraphNode:
             node_dict['mitre_info'] = str(self.mitre_info)
         if self.tags:
             node_dict['tags'] = str(self.tags)
-        if self.observations is not None:
-            node_dict['observations'] = self.observations
-        if hasattr(self, 'reward') and self.reward is not None:
-            node_dict['reward'] = self.reward
 
         return node_dict
 

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -27,7 +27,7 @@ class AttackGraphNode:
     attacker: Optional['Attacker'] = None
 
     # Optional extra metadata for AttackGraphNode
-    extra: Optional[dict] = None
+    extras: Optional[dict] = None
 
     def to_dict(self):
         node_dict = {
@@ -56,8 +56,8 @@ class AttackGraphNode:
             node_dict['mitre_info'] = str(self.mitre_info)
         if self.tags:
             node_dict['tags'] = str(self.tags)
-        if self.extra:
-            node_dict['extra'] = self.extra
+        if self.extras:
+            node_dict['extra'] = self.extras
 
         return node_dict
 

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -21,11 +21,13 @@ class AttackGraphNode:
     is_viable: bool = True
     is_necessary: bool = True
     compromised_by: list['Attacker'] = field(default_factory=list)
-    extra: Optional[dict] = None
     mitre_info: Optional[str] = None
     tags: Optional[list[str]] = None
     attributes: Optional[dict] = None
     attacker: Optional['Attacker'] = None
+
+    # Optional extra metadata for AttackGraphNode
+    extra: Optional[dict] = None
 
     def to_dict(self):
         node_dict = {
@@ -54,6 +56,8 @@ class AttackGraphNode:
             node_dict['mitre_info'] = str(self.mitre_info)
         if self.tags:
             node_dict['tags'] = str(self.tags)
+        if self.extra:
+            node_dict['extra'] = self.extra
 
         return node_dict
 

--- a/maltoolbox/model.py
+++ b/maltoolbox/model.py
@@ -77,7 +77,7 @@ class Model():
                         'duplicate and we do not allow duplicates.')
 
         # Optional field for extra asset data
-        asset.extra = {}
+        asset.extras = {}
 
         logger.debug(
             f'Add {asset.name}(id:{asset.id}) to model "{self.name}".'
@@ -156,7 +156,7 @@ class Model():
         """
 
         # Optional field for extra association data
-        association.extra = {}
+        association.extras = {}
 
         # Field names are the two first values in _properties
         field_names = list(vars(association)['_properties'])[0:2]
@@ -345,9 +345,9 @@ class Model():
         if defenses:
             asset_dict['defenses'] = defenses
 
-        if asset.extra:
+        if asset.extras:
             # Add optional metadata to dict
-            asset_dict['extra'] = asset.extra
+            asset_dict['extra'] = asset.extras
 
         return (asset.id, asset_dict)
 
@@ -371,9 +371,9 @@ class Model():
             }
         }
 
-        if association.extra:
+        if association.extras:
             # Add optional metadata to dict
-            json_association['extra'] = association.extra
+            json_association['extra'] = association.extras
 
         return json_association
 

--- a/tests/attackgraph/test_attackgraph.py
+++ b/tests/attackgraph/test_attackgraph.py
@@ -95,17 +95,15 @@ def test_attackgraph_save_load_no_model_given(
     assert len(example_attackgraph.nodes) == len(loaded_attack_graph.nodes)
 
     # Loaded graph nodes will not have 'asset' since it does not have a model.
-    # Loaded graph nodes will have a 'reward' attribute which original
-    # nodes does not, otherwise they should be the same
     for i, loaded_node in enumerate(loaded_attack_graph.nodes):
         original_node = example_attackgraph.nodes[i]
 
         # Convert loaded and original node to dicts
         loaded_node_dict = loaded_node.to_dict()
         original_node_dict = original_node.to_dict()
-        # Remove keys that don't match
+
+        # Remove key that don't match
         del original_node_dict['asset']
-        del loaded_node_dict['reward']
 
         # Make sure nodes are the same (except for the excluded keys)
         assert loaded_node_dict == original_node_dict
@@ -122,13 +120,8 @@ def test_attackgraph_from_to_from_json_yml_model_given(
         loaded_attackgraph = AttackGraph.load_from_file(
             attackgraph_path, model=example_attackgraph.model)
 
-        # Loaded graph nodes will have a 'reward' attribute which original
-        # nodes does not, otherwise they should be the same
         for i, loaded_node_dict in enumerate(loaded_attackgraph._to_dict()):
             original_node_dict = example_attackgraph._to_dict()[i]
-
-            # Remove key that don't match
-            del loaded_node_dict['reward']
 
             # Make sure nodes are the same (except for the excluded keys)
             assert loaded_node_dict == original_node_dict


### PR DESCRIPTION
`extras` can be used to store optional information, e.g. information about X and Y coordinates if the graph is used in a graphical interface, or rewards if the graph is used for simulation.
 
I also removed some unused fields from AttackGraph as well.