### PR TITLE
Check for duplicate associations

### DIFF
--- a/maltoolbox/exceptions.py
+++ b/maltoolbox/exceptions.py
@@ -30,3 +30,16 @@ class AttackGraphStepExpressionError(AttackGraphException):
     """A target attack step cannot be linked with for a step expression."""
     pass
 
+
+class ModelException(MalToolboxException):
+    """Base Exception for all Model related exceptions"""
+    pass
+
+
+class ModelAssociationException(ModelException):
+    """Exception related to associations in Model"""
+    pass
+
+class DuplicateModelAssociationError(ModelException):
+    """Associations should be unique as part of Model"""
+    pass

--- a/maltoolbox/model.py
+++ b/maltoolbox/model.py
@@ -40,7 +40,7 @@ class Model():
         self.name = name
         self.assets = []
         self.associations = []
-        self.type_to_associations = {}
+        self.type_to_associations = {} # optimization
         self.attackers = []
         self.lang_classes_factory = lang_classes_factory
         self.maltoolbox_version = mt_version
@@ -237,14 +237,13 @@ class Model():
         # Add the association to all of the included assets
         for field_name in field_names:
             for asset in getattr(association, field_name):
-                # Add associations to assets that are part of them
                 asset_assocs = list(asset.associations)
                 asset_assocs.append(association)
                 asset.associations = asset_assocs
 
-        # Add the association to the model
         self.associations.append(association)
 
+        # Add association to type->association mapping
         association_type = association.__class__.__name__
         self.type_to_associations.setdefault(
                 association_type, []
@@ -289,7 +288,7 @@ class Model():
         self.type_to_associations[association_type].remove(
             association
         )
-        # Remove type from type-> association mapping if mapping empty
+        # Remove type from type->association mapping if mapping empty
         if len(self.type_to_associations[association_type]) == 0:
             del self.type_to_associations[association_type]
 

--- a/maltoolbox/model.py
+++ b/maltoolbox/model.py
@@ -180,31 +180,25 @@ class Model():
                 f"Identical association {association_type} already exists"
             )
 
+
+        # Check for duplicate assets in each field
         left_field_name, right_field_name = association._properties.keys()
-        left_field_assets = getattr(association, left_field_name)
-        right_field_assets = getattr(association, right_field_name)
 
-        # Check for duplicate assets in left field
-        unique_left_field_asset_names = {a.name for a in left_field_assets}
-        if len(left_field_assets) > len(unique_left_field_asset_names):
-            raise ModelAssociationException(
-                "More than one asset share same name in left field"
-                f"{association_type}.{left_field_name}"
-            )
+        for field_name in (left_field_name, right_field_name):
+            field_assets = getattr(association, field_name)
 
-        # Check for duplicate assets in right field
-        unique_right_field_asset_names = {a.name for a in right_field_assets}
-        if len(right_field_assets) > len(unique_right_field_asset_names):
-            raise ModelAssociationException(
-                "More than one asset share same name in left field"
-                f"{association_type}.{right_field_name}"
-            )
+            unique_field_asset_names = {a.name for a in field_assets}
+            if len(field_assets) > len(unique_field_asset_names):
+                raise ModelAssociationException(
+                    "More than one asset share same name in field"
+                    f"{association_type}.{field_name}"
+                )
 
         # For each asset in left field, go through each assets in right field
         # to find all unique connections. Raise error if a connection between
         # two assets already exist in a previously added association.
-        for left_asset in left_field_assets:
-            for right_asset in right_field_assets:
+        for left_asset in getattr(association, left_field_name):
+            for right_asset in getattr(association, right_field_name):
 
                 if self.association_exists_between_assets(
                     association_type, left_asset, right_asset

--- a/tests/attackgraph/test_attackgraph.py
+++ b/tests/attackgraph/test_attackgraph.py
@@ -26,7 +26,7 @@ def example_attackgraph(corelang_lang_graph: LanguageGraph, model: Model):
     model.add_asset(app2)
 
     # Create association between app1 and app2
-    assoc = create_association(model, from_assets=[app1], to_assets=[app2])
+    assoc = create_association(model, left_assets=[app1], right_assets=[app2])
     model.add_association(assoc)
 
     attacker = AttackerAttachment()
@@ -191,7 +191,7 @@ def test_attackgraph_according_to_corelang(corelang_lang_graph, model):
     model.add_asset(app2)
 
     # Create association between app1 and app2
-    assoc = create_association(model, from_assets=[app1], to_assets=[app2])
+    assoc = create_association(model, left_assets=[app1], right_assets=[app2])
     model.add_association(assoc)
     attack_graph = AttackGraph(lang_graph=corelang_lang_graph, model=model)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,11 +21,11 @@ def create_data_asset(model, name):
 
 def create_association(
         model,
-        from_assets,
-        to_assets,
+        left_assets,
+        right_assets,
         assoc_type="AppExecution",
-        from_fieldname="hostApp",
-        to_fieldname="appExecutedApps",
+        left_fieldname="hostApp",
+        right_fieldname="appExecutedApps",
     ):
     """Helper function to create an association dict with
     given parameters, useful in tests"""
@@ -33,8 +33,8 @@ def create_association(
     # Simulate receiving the association from a json file
     association_dict = {
       assoc_type: {
-        from_fieldname: from_assets,
-        to_fieldname: to_assets
+        left_fieldname: left_assets,
+        right_fieldname: right_assets
       }
     }
 
@@ -157,8 +157,8 @@ def test_model_add_association(model: Model):
     # Create an association between p1 and p2
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
 
     associations_before = list(model.associations)
@@ -191,8 +191,8 @@ def test_model_add_appexecution_association_two_assets(model: Model):
         # are not allowed in the left field for AppExecution
         create_association(
             model, assoc_type="AppExecution",
-            from_fieldname="hostApp", to_fieldname="appExecutedApps",
-            from_assets=[p1, p2], to_assets=[p1]
+            left_fieldname="hostApp", right_fieldname="appExecutedApps",
+            left_assets=[p1, p2], right_assets=[p1]
         )
 
 
@@ -215,20 +215,20 @@ def test_model_add_association_duplicate(model: Model):
     # Create an association between (d1, d2) and d3
     association1 = create_association(
         model, assoc_type="DataContainment",
-        from_fieldname="containingData", to_fieldname="containedData",
-        from_assets=[d1, d2], to_assets=[d3]
+        left_fieldname="containingData", right_fieldname="containedData",
+        left_assets=[d1, d2], right_assets=[d3]
     )
     # Create an identical association, but from just d2
     association2 = create_association(
         model, assoc_type="DataContainment",
-        from_fieldname="containingData", to_fieldname="containedData",
-        from_assets=[d2], to_assets=[d3]
+        left_fieldname="containingData", right_fieldname="containedData",
+        left_assets=[d2], right_assets=[d3]
     )
     # Create association with duplicate assets in both fields
     association3 = create_association(
         model, assoc_type="DataContainment",
-        from_fieldname="containingData", to_fieldname="containedData",
-        from_assets=[d2, d2], to_assets=[d3, d3]
+        left_fieldname="containingData", right_fieldname="containedData",
+        left_assets=[d2, d2], right_assets=[d3, d3]
     )
 
     # Add the first association to the model - no problem
@@ -273,8 +273,8 @@ def test_model_remove_association(model: Model):
 
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
 
     model.add_association(association)
@@ -298,8 +298,8 @@ def test_model_remove_association_nonexisting(model: Model):
     # Create the association but don't add it
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[], to_assets=[]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[], right_assets=[]
     )
 
     # No associations exists
@@ -323,8 +323,8 @@ def test_model_remove_asset_from_association(model: Model):
     # Create and add association from p1 to p2
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
     model.add_association(association)
 
@@ -355,8 +355,8 @@ def test_model_remove_asset_from_association_nonexisting_asset(
     # Create an association between p1 and p2
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
     model.add_association(association)
 
@@ -385,8 +385,8 @@ def test_model_remove_asset_from_association_nonexisting_association(
     # Create (but don't add!) an association between p1 and p2
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
     # We are removing an association that was never created -> LookupError
     with pytest.raises(LookupError):
@@ -481,8 +481,8 @@ def test_model_get_associated_assets_by_fieldname(model: Model):
     # Create and add an association between p1 and p2
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
     model.add_association(association)
 
@@ -565,8 +565,8 @@ def test_model_association_to_dict(model: Model):
     # Create and add an association between p1 and p2
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
     model.add_association(association)
 
@@ -627,8 +627,8 @@ def test_serialize(model: Model):
     # Create and add an association between p1 and p2
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
     model.add_association(association)
 
@@ -680,8 +680,8 @@ def test_model_save_and_load_model_from_scratch(model: Model):
     # Create and add an association between p1 and p2
     association = create_association(
         model, assoc_type="AppExecution",
-        from_fieldname="hostApp", to_fieldname="appExecutedApps",
-        from_assets=[p1], to_assets=[p2]
+        left_fieldname="hostApp", right_fieldname="appExecutedApps",
+        left_assets=[p1], right_assets=[p2]
     )
     model.add_association(association)
 


### PR DESCRIPTION
Raise exceptions if a user tries to add duplicate or invalid associations

- [x] Add type->associations mapping to Model (for faster lookup)
- [x] Check that added associations are unique
- [x] Check that asset lists (fields) in associations don't contain duplicate assets
- [x] Check that association connections between single assets are unique from previously added associations
- [x] Tests
- [x] Some renaming