### PR TITLE
Simplify convert old model

### DIFF
--- a/maltoolbox/translators/updater.py
+++ b/maltoolbox/translators/updater.py
@@ -136,35 +136,17 @@ def load_model_from_version_0_0_39(
     return None
 
 
-def load_model_and_save_to_new_format(
-        model_file_name,
-        lang_classes_factory,
-        new_model_file_name
-    ):
-    """A wrapper to decide version, load model and save to new maltoolbox format"""
-
-    with open(model_file_name, 'r', encoding='utf-8') as model_file:
-        if model_file_name.endswith('.yml') or model_file_name.endswith('.yaml'):
-            model_dict = yaml.safe_load(model_file)
-        elif model_file_name.endswith('json'):
-            model_dict = json.load(model_file)
-
-        version = model_dict['metadata']['MAL Toolbox Version']
-        model = load_model_from_older_version(
-            model_file_name, lang_classes_factory, version)
-        model.save_to_file(new_model_file_name)
-
 if __name__ == '__main__':
     """CLI to load old version model and save to new format"""
     parser = argparse.ArgumentParser()
     parser.add_argument('model_file', type=str)
     parser.add_argument('language', type=str, help=".mar file")
+    parser.add_argument('mal_toolbox_version', type=str, help="X.X.X")
     parser.add_argument('outfile', type=str, help="outfile for new converted model")
     args = parser.parse_args()
 
     lang_graph = LanguageGraph.from_mar_archive(args.language)
     lang_classes_factory = LanguageClassesFactory(lang_graph)
-
-    load_model_and_save_to_new_format(
-        args.model_file, lang_classes_factory, args.outfile
-    )
+    model = load_model_from_older_version(
+        args.model_file, lang_classes_factory, args.mal_toolbox_version)
+    model.save_to_file(args.outfile)

--- a/tests/testdata/example_model_0.0.38.json
+++ b/tests/testdata/example_model_0.0.38.json
@@ -1,0 +1,140 @@
+{
+  "metadata": {
+    "name": "Example Model",
+    "langVersion": "1.0.0",
+    "langID": "org.mal-lang.coreLang",
+    "malVersion": "0.1.0-SNAPSHOT",
+    "info": "Created by the mal-toolbox model python module."
+  },
+  "assets": {
+    "0": {
+      "name": "OS App",
+      "metaconcept": "Application",
+      "eid": "0",
+      "defenses": {}
+    },
+    "1": {
+      "name": "Program 1",
+      "metaconcept": "Application",
+      "eid": "1",
+      "defenses": {}
+    },
+    "2": {
+      "name": "SoftwareVulnerability:2",
+      "metaconcept": "SoftwareVulnerability",
+      "eid": "2",
+      "defenses": {}
+    },
+    "3": {
+      "name": "Data:3",
+      "metaconcept": "Data",
+      "eid": "3",
+      "defenses": {}
+    },
+    "4": {
+      "name": "Credentials:4",
+      "metaconcept": "Credentials",
+      "eid": "4",
+      "defenses": {}
+    },
+    "5": {
+      "name": "Identity:5",
+      "metaconcept": "Identity",
+      "eid": "5",
+      "defenses": {}
+    },
+    "6": {
+      "name": "ConnectionRule:6",
+      "metaconcept": "ConnectionRule",
+      "eid": "6",
+      "defenses": {}
+    },
+    "7": {
+      "name": "Other OS App",
+      "metaconcept": "Application",
+      "eid": "7",
+      "defenses": {}
+    }
+  },
+  "associations": [
+    {
+      "metaconcept": "AppExecution",
+      "association": {
+        "hostApp": [
+          "0"
+        ],
+        "appExecutedApps": [
+          "1"
+        ]
+      }
+    },
+    {
+      "metaconcept": "ApplicationVulnerability_SoftwareVulnerability_Application",
+      "association": {
+        "vulnerabilities": [
+          "2"
+        ],
+        "application": [
+          "0"
+        ]
+      }
+    },
+    {
+      "metaconcept": "AppContainment",
+      "association": {
+        "containedData": [
+          "3"
+        ],
+        "containingApp": [
+          "1"
+        ]
+      }
+    },
+    {
+      "metaconcept": "IdentityCredentials",
+      "association": {
+        "identities": [
+          "5"
+        ],
+        "credentials": [
+          "4"
+        ]
+      }
+    },
+    {
+      "metaconcept": "InfoContainment",
+      "association": {
+        "containerData": [
+          "3"
+        ],
+        "information": [
+          "4"
+        ]
+      }
+    },
+    {
+      "metaconcept": "ApplicationConnection",
+      "association": {
+        "applications": [
+          "0",
+          "7"
+        ],
+        "appConnections": [
+          "6"
+        ]
+      }
+    }
+  ],
+  "attackers": {
+    "8": {
+      "name": "Attacker:8",
+      "entry_points": {
+        "0": {
+          "attack_steps": [
+            "networkConnectUninspected"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a small CLI (maltoolbox.translators.updater) that can be used to convert old models to new ones with just command line.