### PR TITLE
Add custom deepcopy to AttackGraph and AttackGraphNode

### DIFF
--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -2,6 +2,7 @@
 MAL-Toolbox Attack Graph Module
 """
 from __future__ import annotations
+import copy
 import logging
 import json
 
@@ -223,6 +224,30 @@ class AttackGraph():
             'attack_steps': serialized_attack_steps,
             'attackers': serialized_attackers,
         }
+
+    def __deepcopy__(self, memo):
+        copied_attackgraph = AttackGraph(self.lang_graph)
+        copied_attackgraph.model = self.model
+
+        # Deep copy nodes and add references to them
+        copied_attackgraph.nodes = copy.deepcopy(self.nodes, memo)
+
+        # Deep copy attackers and references to them
+        copied_attackgraph.attackers = copy.deepcopy(self.attackers, memo)
+
+        # Copy lookup dicts
+        copied_attackgraph._id_to_attacker = \
+            copy.deepcopy(self._id_to_attacker, memo)
+        copied_attackgraph._id_to_node = \
+            copy.deepcopy(self._id_to_node, memo)
+        copied_attackgraph._full_name_to_node = \
+            copy.deepcopy(self._full_name_to_node, memo)
+
+        # Copy counters
+        copied_attackgraph.next_node_id = self.next_node_id
+        copied_attackgraph.next_attacker_id = self.next_attacker_id
+
+        return copied_attackgraph
 
     def save_to_file(self, filename: str) -> None:
         """Save to json/yml depending on extension"""

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -3,6 +3,7 @@ MAL-Toolbox Attack Graph Node Dataclass
 """
 
 from __future__ import annotations
+import copy
 from dataclasses import field, dataclass
 from typing import Any, Optional
 
@@ -68,6 +69,39 @@ class AttackGraphNode:
 
     def __repr__(self) -> str:
         return str(self.to_dict())
+
+    def __deepcopy__(self, memo) -> AttackGraphNode:
+        """Deep copy an attackgraph node"""
+
+        copied_node = AttackGraphNode(
+            self.type,
+            self.name,
+            self.ttc,
+            self.id,
+            self.asset,
+            [],
+            [],
+            self.defense_status,
+            self.existence_status,
+            self.is_viable,
+            self.is_necessary,
+            copy.deepcopy(self.compromised_by, memo),
+            self.mitre_info,
+            copy.deepcopy(self.tags, memo),
+            copy.deepcopy(self.attributes, memo),
+            copy.deepcopy(self.extras, memo)
+        )
+
+        # Remember that self was already copied
+        memo[id(self)] = copied_node
+
+        # Deep copy children and parents, send memo (avoid infinite recursion)
+        if self.parents:
+            copied_node.parents = copy.deepcopy(self.parents, memo)
+        if self.children:
+            copied_node.children = copy.deepcopy(self.children, memo)
+
+        return copied_node
 
     def is_compromised(self) -> bool:
         """

--- a/tests/attackgraph/test_attackgraph.py
+++ b/tests/attackgraph/test_attackgraph.py
@@ -1,5 +1,6 @@
 """Unit tests for AttackGraph functionality"""
 
+import copy
 import pytest
 from unittest.mock import patch
 
@@ -403,3 +404,46 @@ def test_attackgraph_remove_node(example_attackgraph: AttackGraph):
         assert node_to_remove not in parent.children
     for child in children:
         assert node_to_remove not in child.parents
+
+
+def test_attackgraph_deepcopy(example_attackgraph: AttackGraph):
+    """
+    Try to deepcopy an attackgraph object. The nodes of the attack graph
+    and attackers should be duplicated into new objects, while references to
+    the instance model should remain the same.
+    """
+    copied_attackgraph: AttackGraph = copy.deepcopy(example_attackgraph)
+
+    assert copied_attackgraph != example_attackgraph
+    assert copied_attackgraph._to_dict() == example_attackgraph._to_dict()
+
+    assert copied_attackgraph.next_node_id == example_attackgraph.next_node_id
+    assert copied_attackgraph.next_attacker_id == example_attackgraph.next_attacker_id
+
+    assert len(copied_attackgraph.nodes) == len(example_attackgraph.nodes)
+
+    assert list(copied_attackgraph._id_to_node.keys()) \
+        == list(example_attackgraph._id_to_node.keys())
+
+    assert list(copied_attackgraph._id_to_attacker.keys()) \
+        == list(example_attackgraph._id_to_attacker.keys())
+
+    assert list(copied_attackgraph._full_name_to_node.keys()) \
+        == list(example_attackgraph._full_name_to_node.keys())
+
+    assert id(copied_attackgraph.model) == id(example_attackgraph.model)
+
+    for node in copied_attackgraph.nodes:
+        assert node.id is not None
+        original_node = example_attackgraph.get_node_by_id(node.id)
+        assert original_node
+        assert id(original_node) != id(node)
+        assert original_node.to_dict() == node.to_dict()
+        assert id(original_node.asset) == id(node.asset)
+
+    for attacker in copied_attackgraph.attackers:
+        assert attacker.id is not None
+        original_attacker = example_attackgraph.get_attacker_by_id(attacker.id)
+        assert original_attacker
+        assert id(original_attacker) != id(attacker)
+        assert original_attacker.to_dict() == attacker.to_dict()


### PR DESCRIPTION
- Make sure that each node is copied once by using 'memo'.
- Copy lookup dicts for nodes/attackers.
- Add a test to make sure deep copy works as expected.