### PR TITLE
Bugfix deepcopy

### DIFF
--- a/maltoolbox/attackgraph/attacker.py
+++ b/maltoolbox/attackgraph/attacker.py
@@ -4,6 +4,7 @@ MAL-Toolbox Attack Graph Attacker Class
 
 from __future__ import annotations
 from dataclasses import dataclass, field
+import copy
 import logging
 
 from typing import Optional
@@ -40,6 +41,28 @@ class Attacker:
 
     def __repr__(self) -> str:
         return str(self.to_dict())
+
+    def __deepcopy__(self, memo) -> Attacker:
+        """Deep copy an Attacker"""
+
+        # Check if the object is already in the memo dictionary
+        if id(self) in memo:
+            return memo[id(self)]
+
+        copied_attacker = Attacker(
+            id=self.id,
+            name=self.name,
+        )
+
+        # Remember that self was already copied
+        memo[id(self)] = copied_attacker
+
+        copied_attacker.entry_points = copy.deepcopy(
+            self.entry_points, memo=memo)
+        copied_attacker.reached_attack_steps = copy.deepcopy(
+            self.reached_attack_steps, memo=memo)
+
+        return copied_attacker
 
     def compromise(self, node: AttackGraphNode) -> None:
         """

--- a/maltoolbox/attackgraph/attacker.py
+++ b/maltoolbox/attackgraph/attacker.py
@@ -50,17 +50,17 @@ class Attacker:
             return memo[id(self)]
 
         copied_attacker = Attacker(
-            id=self.id,
-            name=self.name,
+            id = self.id,
+            name = self.name,
         )
 
         # Remember that self was already copied
         memo[id(self)] = copied_attacker
 
         copied_attacker.entry_points = copy.deepcopy(
-            self.entry_points, memo=memo)
+            self.entry_points, memo = memo)
         copied_attacker.reached_attack_steps = copy.deepcopy(
-            self.reached_attack_steps, memo=memo)
+            self.reached_attack_steps, memo = memo)
 
         return copied_attacker
 

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -234,11 +234,28 @@ class AttackGraph():
         copied_attackgraph = AttackGraph(self.lang_graph)
         copied_attackgraph.model = self.model
 
-        # Deep copy nodes and references to them
-        copied_attackgraph.nodes = copy.deepcopy(self.nodes, memo)
+        copied_attackgraph.nodes = []
+
+        # Deep copy nodes
+        for node in self.nodes:
+            copied_node = copy.deepcopy(node, memo)
+            copied_attackgraph.nodes.append(copied_node)
+
+        # Re-link node references
+        for node in self.nodes:
+            if node.parents:
+                memo[id(node)].parents = copy.deepcopy(node.parents, memo)
+            if node.children:
+                memo[id(node)].children = copy.deepcopy(node.children, memo)
 
         # Deep copy attackers and references to them
         copied_attackgraph.attackers = copy.deepcopy(self.attackers, memo)
+
+        # Re-link attacker references
+        for node in self.nodes:
+            if node.compromised_by:
+                memo[id(node)].compromised_by = copy.deepcopy(
+                    node.compromised_by, memo)
 
         # Copy lookup dicts
         copied_attackgraph._id_to_attacker = \

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -226,10 +226,15 @@ class AttackGraph():
         }
 
     def __deepcopy__(self, memo):
+
+        # Check if the object is already in the memo dictionary
+        if id(self) in memo:
+            return memo[id(self)]
+
         copied_attackgraph = AttackGraph(self.lang_graph)
         copied_attackgraph.model = self.model
 
-        # Deep copy nodes and add references to them
+        # Deep copy nodes and references to them
         copied_attackgraph.nodes = copy.deepcopy(self.nodes, memo)
 
         # Deep copy attackers and references to them

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -73,6 +73,10 @@ class AttackGraphNode:
     def __deepcopy__(self, memo) -> AttackGraphNode:
         """Deep copy an attackgraph node"""
 
+        # Check if the object is already in the memo dictionary
+        if id(self) in memo:
+            return memo[id(self)]
+
         copied_node = AttackGraphNode(
             self.type,
             self.name,
@@ -85,15 +89,20 @@ class AttackGraphNode:
             self.existence_status,
             self.is_viable,
             self.is_necessary,
-            copy.deepcopy(self.compromised_by, memo),
+            [],
             self.mitre_info,
-            copy.deepcopy(self.tags, memo),
-            copy.deepcopy(self.attributes, memo),
-            copy.deepcopy(self.extras, memo)
+            [],
+            [],
+            {}
         )
 
         # Remember that self was already copied
         memo[id(self)] = copied_node
+
+        copied_node.compromised_by = copy.deepcopy(self.compromised_by, memo)
+        copied_node.tags = copy.deepcopy(self.tags, memo)
+        copied_node.attributes = copy.deepcopy(self.attributes, memo)
+        copied_node.extras = copy.deepcopy(self.extras, memo)
 
         # Deep copy children and parents, send memo (avoid infinite recursion)
         if self.parents:

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -92,7 +92,7 @@ class AttackGraphNode:
             [],
             self.mitre_info,
             [],
-            [],
+            {},
             {}
         )
 

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -71,7 +71,14 @@ class AttackGraphNode:
         return str(self.to_dict())
 
     def __deepcopy__(self, memo) -> AttackGraphNode:
-        """Deep copy an attackgraph node"""
+        """Deep copy an attackgraph node
+
+        The deepcopy will copy over node specific information, such as type,
+        name, etc., but it will not copy attack graph relations such as
+        parents, children, or attackers it is compromised by. These references
+        should be recreated when deepcopying the attack graph itself.
+
+        """
 
         # Check if the object is already in the memo dictionary
         if id(self) in memo:
@@ -96,19 +103,12 @@ class AttackGraphNode:
             {}
         )
 
-        # Remember that self was already copied
-        memo[id(self)] = copied_node
-
-        copied_node.compromised_by = copy.deepcopy(self.compromised_by, memo)
         copied_node.tags = copy.deepcopy(self.tags, memo)
         copied_node.attributes = copy.deepcopy(self.attributes, memo)
         copied_node.extras = copy.deepcopy(self.extras, memo)
 
-        # Deep copy children and parents, send memo (avoid infinite recursion)
-        if self.parents:
-            copied_node.parents = copy.deepcopy(self.parents, memo)
-        if self.children:
-            copied_node.children = copy.deepcopy(self.children, memo)
+        # Remember that self was already copied
+        memo[id(self)] = copied_node
 
         return copied_node
 


### PR DESCRIPTION
Deepcopy did not work as it should it turns out.

First, we should check if memo contains the object first in our __deepcopy__ implementations.
Secondly, we needed __deepcopy__ implemented for the Attacker as well.

I also added some tests that were failing before but now work as they should with the new deepcopy implementation.
This probably also solves the recursion limit issue that we had in the simulator with big graph. I will check this.