### PR TITLE
Add LookupDict for faster and simpler lookups

### DIFF
--- a/maltoolbox/attackgraph/analyzers/apriori.py
+++ b/maltoolbox/attackgraph/analyzers/apriori.py
@@ -162,7 +162,7 @@ def calculate_viability_and_necessity(graph: AttackGraph) -> None:
     graph       - the attack graph for which we wish to determine the
                   viability and necessity statuses for the nodes.
     """
-    for node in graph.nodes:
+    for node in graph.nodes.values():
         if node.type in ['exist', 'notExist', 'defense']:
             evaluate_viability_and_necessity(node)
             if not node.is_viable:
@@ -178,7 +178,7 @@ def prune_unviable_and_unnecessary_nodes(graph: AttackGraph) -> None:
                   the nodes which are not viable or necessary.
     """
     logger.debug('Prune unviable and unnecessary nodes from the attack graph.')
-    for node in graph.nodes:
+    for node in graph.nodes.values():
         if (node.type == 'or' or node.type == 'and') and \
             (not node.is_viable or not node.is_necessary):
             graph.remove_node(node)

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -2,10 +2,10 @@
 MAL-Toolbox Attack Graph Module
 """
 from __future__ import annotations
-import copy
 import logging
 import json
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from .node import AttackGraphNode
@@ -19,6 +19,7 @@ from ..file_utils import (
     load_dict_from_yaml_file,
     save_dict_to_file
 )
+from ..utils import LookupDict
 
 
 if TYPE_CHECKING:
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 class AttackGraph():
     """Graph representation of attack steps"""
     def __init__(self, lang_graph = None, model: Optional[Model] = None):
-        self.nodes: list[AttackGraphNode] = []
+        self.nodes: LookupDict[str, AttackGraphNode] = LookupDict()
         self.attackers: list[Attacker] = []
         # Dictionaries used in optimization to get nodes and attackers by id
         # or full name faster
@@ -52,7 +53,7 @@ class AttackGraph():
         """Convert AttackGraph to dict"""
         serialized_attack_steps = {}
         serialized_attackers = {}
-        for ag_node in self.nodes:
+        for ag_node in self.nodes.values():
             serialized_attack_steps[ag_node.full_name] =\
                 ag_node.to_dict()
         for attacker in self.attackers:
@@ -72,40 +73,26 @@ class AttackGraph():
             return memo[id(self)]
 
         copied_attackgraph = AttackGraph(self.lang_graph)
+
+        memo[id(self)] = copied_attackgraph
+
         copied_attackgraph.model = self.model
+        copied_attackgraph.nodes = deepcopy(self.nodes, memo)
+        copied_attackgraph.attackers = deepcopy(self.attackers, memo)
 
-        copied_attackgraph.nodes = []
-
-        # Deep copy nodes
-        for node in self.nodes:
-            copied_node = copy.deepcopy(node, memo)
-            copied_attackgraph.nodes.append(copied_node)
-
-        # Re-link node references
-        for node in self.nodes:
+        for node in self.nodes.values():
+            nid = id(node)
             if node.parents:
-                memo[id(node)].parents = copy.deepcopy(node.parents, memo)
+                memo[nid].parents = deepcopy(node.parents, memo)
             if node.children:
-                memo[id(node)].children = copy.deepcopy(node.children, memo)
-
-        # Deep copy attackers and references to them
-        copied_attackgraph.attackers = copy.deepcopy(self.attackers, memo)
-
-        # Re-link attacker references
-        for node in self.nodes:
+                memo[nid].children = deepcopy(node.children, memo)
             if node.compromised_by:
-                memo[id(node)].compromised_by = copy.deepcopy(
-                    node.compromised_by, memo)
+                memo[nid].compromised_by = deepcopy(node.compromised_by, memo)
 
-        # Copy lookup dicts
-        copied_attackgraph._id_to_attacker = \
-            copy.deepcopy(self._id_to_attacker, memo)
-        copied_attackgraph._id_to_node = \
-            copy.deepcopy(self._id_to_node, memo)
-        copied_attackgraph._full_name_to_node = \
-            copy.deepcopy(self._full_name_to_node, memo)
+        copied_attackgraph._id_to_attacker = deepcopy(self._id_to_attacker, memo)
+        copied_attackgraph._id_to_node = deepcopy(self._id_to_node, memo)
+        copied_attackgraph._full_name_to_node = deepcopy(self._full_name_to_node, memo)
 
-        # Copy counters
         copied_attackgraph.next_node_id = self.next_node_id
         copied_attackgraph.next_attacker_id = self.next_attacker_id
 
@@ -593,7 +580,7 @@ class AttackGraph():
             asset.attack_step_nodes = attack_step_nodes
 
         # Then, link all of the nodes according to their associations.
-        for ag_node in self.nodes:
+        for ag_node in self.nodes.values():
             logger.debug(
                 'Determining children for attack step "%s"(%d)',
                 ag_node.full_name,
@@ -667,7 +654,7 @@ class AttackGraph():
         the MAL language specification provided at initialization.
         """
 
-        self.nodes = []
+        self.nodes = LookupDict()
         self.attackers = []
         self._generate_graph()
 
@@ -694,7 +681,7 @@ class AttackGraph():
         node.id = node_id if node_id is not None else self.next_node_id
         self.next_node_id = max(node.id + 1, self.next_node_id)
 
-        self.nodes.append(node)
+        self.nodes[node.id] = node
         self._id_to_node[node.id] = node
         self._full_name_to_node[node.full_name] = node
 
@@ -710,7 +697,7 @@ class AttackGraph():
             child.parents.remove(node)
         for parent in node.parents:
             parent.children.remove(node)
-        self.nodes.remove(node)
+        self.nodes.pop(node.id)  # type: ignore[call-overload]
 
         if not isinstance(node.id, int):
             raise ValueError(f'Invalid node id.')

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -168,7 +168,7 @@ class AttackGraph():
 
         # Re-establish links between nodes.
         for node_full_name, node_dict in serialized_attack_steps.items():
-            _ag_node = attack_graph.get_node_by_id(node_dict['id'])
+            _ag_node = attack_graph.nodes[node_dict['id']]
             if not isinstance(_ag_node, AttackGraphNode):
                 msg = ('Failed to find node with id %s when loading'
                        ' attack graph from dict')
@@ -176,7 +176,7 @@ class AttackGraph():
                 raise LookupError(msg % node_dict["id"])
             else:
                 for child_id in node_dict['children']:
-                    child = attack_graph.get_node_by_id(int(child_id))
+                    child = attack_graph.nodes[int(child_id)]
                     if child is None:
                         msg = ('Failed to find child node with id %s'
                                ' when loading from attack graph from dict')
@@ -185,7 +185,7 @@ class AttackGraph():
                     _ag_node.children.append(child)
 
                 for parent_id in node_dict['parents']:
-                    parent = attack_graph.get_node_by_id(int(parent_id))
+                    parent = attack_graph.nodes[int(parent_id)]
                     if parent is None:
                         msg = ('Failed to find parent node with id %s '
                                'when loading from attack graph from dict')
@@ -232,20 +232,6 @@ class AttackGraph():
         else:
             raise ValueError('Unknown file extension, expected json/yml/yaml')
         return cls._from_dict(serialized_attack_graph, model=model)
-
-    def get_node_by_id(self, node_id: int) -> Optional[AttackGraphNode]:
-        """
-        Return the attack node that matches the id provided.
-
-        Arguments:
-        node_id     - the id of the attack graph node we are looking for
-
-        Return:
-        The attack step node that matches the given id.
-        """
-
-        logger.debug('Looking up node with id %s', node_id)
-        return self._id_to_node.get(node_id)
 
     def get_node_by_full_name(self, full_name: str) -> Optional[AttackGraphNode]:
         """
@@ -741,7 +727,7 @@ class AttackGraph():
 
         self.next_attacker_id = max(attacker.id + 1, self.next_attacker_id)
         for node_id in reached_attack_steps:
-            node = self.get_node_by_id(node_id)
+            node = self.nodes[node_id]
             if node:
                 attacker.compromise(node)
             else:
@@ -750,7 +736,7 @@ class AttackGraph():
                 logger.error(msg, node_id)
                 raise AttackGraphException(msg % node_id)
         for node_id in entry_points:
-            node = self.get_node_by_id(int(node_id))
+            node = self.nodes[int(node_id)]
             if node:
                 attacker.entry_points.append(node)
             else:

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -35,8 +35,6 @@ class AttackGraph():
         self.attackers: list[Attacker] = []
         # Dictionaries used in optimization to get nodes and attackers by id
         # or full name faster
-        self._id_to_node: dict[int, AttackGraphNode] = {}
-        self._full_name_to_node: dict[str, AttackGraphNode] = {}
         self._id_to_attacker: dict[int, Attacker] = {}
 
         self.model = model
@@ -90,8 +88,6 @@ class AttackGraph():
                 memo[nid].compromised_by = deepcopy(node.compromised_by, memo)
 
         copied_attackgraph._id_to_attacker = deepcopy(self._id_to_attacker, memo)
-        copied_attackgraph._id_to_node = deepcopy(self._id_to_node, memo)
-        copied_attackgraph._full_name_to_node = deepcopy(self._full_name_to_node, memo)
 
         copied_attackgraph.next_node_id = self.next_node_id
         copied_attackgraph.next_attacker_id = self.next_attacker_id
@@ -646,15 +642,13 @@ class AttackGraph():
                 f'with id:{node_id}:\n' \
                 + json.dumps(node.to_dict(), indent = 2))
 
-        if node.id in self._id_to_node:
+        if node.id in self.nodes:
             raise ValueError(f'Node index {node_id} already in use.')
 
         node.id = node_id if node_id is not None else self.next_node_id
         self.next_node_id = max(node.id + 1, self.next_node_id)
 
         self.nodes[node.id] = node
-        self._id_to_node[node.id] = node
-        self._full_name_to_node[node.full_name] = node
 
     def remove_node(self, node: AttackGraphNode) -> None:
         """Remove node from attack graph
@@ -672,8 +666,6 @@ class AttackGraph():
 
         if not isinstance(node.id, int):
             raise ValueError(f'Invalid node id.')
-        del self._id_to_node[node.id]
-        del self._full_name_to_node[node.full_name]
 
     def add_attacker(
             self,

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -555,7 +555,7 @@ class AttackGraph():
                         # Resolve step expression associated with
                         # (non-)existence attack steps.
                         existence_status = False
-                        for requirement in attack_step.get_all_requirements():
+                        for requirement in attack_step.requires:
                             target_assets = self._follow_expr_chain(
                                     self.model,
                                     [asset],

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -233,21 +233,6 @@ class AttackGraph():
             raise ValueError('Unknown file extension, expected json/yml/yaml')
         return cls._from_dict(serialized_attack_graph, model=model)
 
-    def get_node_by_full_name(self, full_name: str) -> Optional[AttackGraphNode]:
-        """
-        Return the attack node that matches the full name provided.
-
-        Arguments:
-        full_name   - the full name of the attack graph node we are looking
-                      for
-
-        Return:
-        The attack step node that matches the given full name.
-        """
-
-        logger.debug(f'Looking up node with full name "%s"', full_name)
-        return self._full_name_to_node.get(full_name)
-
     def get_attacker_by_id(self, attacker_id: int) -> Optional[Attacker]:
         """
         Return the attacker that matches the id provided.
@@ -294,7 +279,7 @@ class AttackGraph():
             for (asset, attack_steps) in attacker_info.entry_points:
                 for attack_step in attack_steps:
                     full_name = asset.name + ':' + attack_step
-                    ag_node = self.get_node_by_full_name(full_name)
+                    ag_node = self.nodes.fetch("full_name", full_name)
                     if not ag_node:
                         logger.warning(
                             'Failed to find attacker entry point '
@@ -595,8 +580,8 @@ class AttackGraph():
                             if target_asset is not None:
                                 target_node_full_name = target_asset.name + \
                                     ':' + target_attack_step.name
-                                target_node = self.get_node_by_full_name(
-                                    target_node_full_name)
+                                target_node = self.nodes.fetch("full_name",
+                                     target_node_full_name)
                                 if target_node is None:
                                     msg = ('Failed to find target node '
                                            '"%s" to link with for attack '

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 class AttackGraph():
     """Graph representation of attack steps"""
     def __init__(self, lang_graph = None, model: Optional[Model] = None):
-        self.nodes: LookupDict[str, AttackGraphNode] = LookupDict()
+        self.nodes: LookupDict[int, AttackGraphNode] = LookupDict()
         self.attackers: list[Attacker] = []
         # Dictionaries used in optimization to get nodes and attackers by id
         # or full name faster
@@ -662,7 +662,7 @@ class AttackGraph():
             child.parents.remove(node)
         for parent in node.parents:
             parent.children.remove(node)
-        self.nodes.pop(node.id)  # type: ignore[call-overload]
+        self.nodes.pop(node.id)  # type: ignore[call-overload,arg-type]
 
         if not isinstance(node.id, int):
             raise ValueError(f'Invalid node id.')

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -112,6 +112,9 @@ class AttackGraphNode:
 
         return copied_node
 
+    def __hash__(self):
+        return hash(self.full_name)
+
     def is_compromised(self) -> bool:
         """
         Return True if any attackers have compromised this node.

--- a/maltoolbox/attackgraph/query.py
+++ b/maltoolbox/attackgraph/query.py
@@ -186,7 +186,7 @@ def get_defense_surface(graph: AttackGraph) -> list[AttackGraphNode]:
     graph       - the attack graph
     """
     logger.debug('Get the defense surface.')
-    return [node for node in graph.nodes if node.is_available_defense()]
+    return [node for node in graph.nodes.values() if node.is_available_defense()]
 
 def get_enabled_defenses(graph: AttackGraph) -> list[AttackGraphNode]:
     """
@@ -197,4 +197,4 @@ def get_enabled_defenses(graph: AttackGraph) -> list[AttackGraphNode]:
     graph       - the attack graph
     """
     logger.debug('Get the enabled defenses.')
-    return [node for node in graph.nodes if node.is_enabled_defense()]
+    return [node for node in graph.nodes.values() if node.is_enabled_defense()]

--- a/maltoolbox/language/classes_factory.py
+++ b/maltoolbox/language/classes_factory.py
@@ -43,9 +43,10 @@ class LanguageClassesFactory:
                     'type' : 'string',
                     'default': asset_name
                 }
-            if asset.super_asset:
+            if asset.own_super_asset:
                 asset_json_entry['allOf'] = [
-                    {'$ref': '#/definitions/LanguageAsset/definitions/Asset_' + asset.super_asset.name}
+                    {'$ref': '#/definitions/LanguageAsset/definitions/Asset_'\
+                        + asset.own_super_asset.name}
                 ]
             for step_name, step in asset.attack_steps.items():
                 if step.type == 'defense':

--- a/maltoolbox/utils.py
+++ b/maltoolbox/utils.py
@@ -1,8 +1,11 @@
 import operator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, TypeVar
 
-class LookupDict(dict):
+K = TypeVar("K")
+V = TypeVar("V")
+
+class LookupDict(Dict[K, V]):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._indices = {}

--- a/maltoolbox/utils.py
+++ b/maltoolbox/utils.py
@@ -57,24 +57,3 @@ class LookupDict(Dict[K, V]):
             return next(iter(ret))
         except KeyError:
             return None
-
-@dataclass
-class Asset:
-    id: int
-    name: str
-    props: list
-    def __hash__(self):
-        return self.name
-
-
-class Test:
-    def __init__(self):
-        self.assets = LookupDict({
-                "one": Asset("one", 1, [0,1,2]), "two": Asset("two", 2,
-                                                              [1,2,3]), "three":
-                Asset("thre", 3, [2,3,4])})
-
-t=Test()
-t.assets.lookup('name', 'one')
-t.assets["four"] = Asset("four",4, [3,4,5])
-t.assets.lookup('name', 'four')

--- a/maltoolbox/utils.py
+++ b/maltoolbox/utils.py
@@ -22,7 +22,7 @@ class LookupDict(Dict[K, V]):
         if key not in self._indices:
             self._indices[key] = {getattr(v, key): set() for v in self.values()}
             for v in self.values():
-                if not (vkey:=getattr(v, key)) in self._indices.keys():
+                if not (vkey:=getattr(v, key)) in self._indices[key].keys():
                     self._indices[key][vkey] = set()
 
                 self._indices[key][vkey].add(v)
@@ -47,6 +47,16 @@ class LookupDict(Dict[K, V]):
 
         return ret
 
+    def fetch(self, key: str, value: Any, op: str="eq") -> Any:
+        ret = self.lookup(key, value, op)
+
+        if len(ret) > 1:
+            raise ValueError(f"Multiple items match {key} ~ {op} ~ {value}")
+
+        try:
+            return next(iter(ret))
+        except KeyError:
+            return None
 
 @dataclass
 class Asset:

--- a/maltoolbox/utils.py
+++ b/maltoolbox/utils.py
@@ -1,0 +1,67 @@
+import operator
+from dataclasses import dataclass
+from typing import Any
+
+class LookupDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._indices = {}
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        self._indices.clear()
+
+    def __delitem__(self, key):
+        super().__delitem__(key)
+        self._indices.clear()
+
+    def lookup(self, key: str, value: Any, op: str ="eq") -> set[Any]:
+        if key not in self._indices:
+            self._indices[key] = {getattr(v, key): set() for v in self.values()}
+            for v in self.values():
+                if not (vkey:=getattr(v, key)) in self._indices.keys():
+                    self._indices[key][vkey] = set()
+
+                self._indices[key][vkey].add(v)
+
+        if op == "eq":
+            try:
+                return self._indices[key][value]
+            except KeyError:
+                return set()
+
+        if op == "in":
+            oper = lambda a, b: operator.contains(b, a)
+        else:
+            try:
+                oper = getattr(operator, op)
+            except AttributeError:
+                raise ValueError(f"Invalid operator {op}")
+
+        ret = set()
+        for i in filter(lambda k: oper(k, value), self._indices[key]):
+            ret.update(self._indices[key][i])
+
+        return ret
+
+
+@dataclass
+class Asset:
+    id: int
+    name: str
+    props: list
+    def __hash__(self):
+        return self.name
+
+
+class Test:
+    def __init__(self):
+        self.assets = LookupDict({
+                "one": Asset("one", 1, [0,1,2]), "two": Asset("two", 2,
+                                                              [1,2,3]), "three":
+                Asset("thre", 3, [2,3,4])})
+
+t=Test()
+t.assets.lookup('name', 'one')
+t.assets["four"] = Asset("four",4, [3,4,5])
+t.assets.lookup('name', 'four')

--- a/tests/attackgraph/test_attackgraph.py
+++ b/tests/attackgraph/test_attackgraph.py
@@ -8,6 +8,7 @@ from maltoolbox.language import LanguageGraph, LanguageClassesFactory
 from maltoolbox.language.compiler import MalCompiler
 from maltoolbox.attackgraph import AttackGraph, AttackGraphNode, Attacker
 from maltoolbox.model import Model, AttackerAttachment
+from maltoolbox.utils import LookupDict
 
 from test_model import create_application_asset, create_association
 
@@ -111,7 +112,7 @@ def attackgraph_save_load_no_model_given(
     assert len(example_attackgraph.nodes) == len(loaded_attack_graph.nodes)
 
     # Loaded graph nodes will not have 'asset' since it does not have a model.
-    for loaded_node in loaded_attack_graph.nodes:
+    for loaded_node in loaded_attack_graph.nodes.values():
         if not isinstance(loaded_node.id, int):
             raise ValueError(f'Invalid node id for loaded node.')
         original_node = example_attackgraph.get_node_by_id(loaded_node.id)
@@ -201,7 +202,7 @@ def attackgraph_save_and_load_json_yml_model_given(
             # Make sure nodes are the same (except for the excluded keys)
             assert loaded_node_dict == original_node_dict
 
-        for node in loaded_attackgraph.nodes:
+        for node in loaded_attackgraph.nodes.values():
             # Make sure node gets an asset when loaded with model
             assert node.asset
             assert node.full_name == node.asset.name + ":" + node.name
@@ -242,7 +243,7 @@ def test_attackgraph_save_and_load_json_yml_model_given_with_attackers(
 def test_attackgraph_get_node_by_id(example_attackgraph: AttackGraph):
     """Make sure get_node_by_id works as intended"""
     assert len(example_attackgraph.nodes)  # make sure loop is run
-    for node in example_attackgraph.nodes:
+    for node in example_attackgraph.nodes.values():
         if not isinstance(node.id, int):
             raise ValueError(f'Invalid node id.')
         get_node = example_attackgraph.get_node_by_id(node.id)
@@ -288,7 +289,7 @@ def test_attackgraph_generate_graph(example_attackgraph: AttackGraph):
     # TODO: Add test cases with defense steps
 
     # Empty the attack graph
-    example_attackgraph.nodes = []
+    example_attackgraph.nodes = LookupDict()
     example_attackgraph.attackers = []
 
     # Generate the attack graph again
@@ -412,7 +413,7 @@ def test_attackgraph_remove_node(example_attackgraph: AttackGraph):
     example_attackgraph.remove_node(node_to_remove)
 
     # Make sure it was correctly removed from list of nodes
-    assert node_to_remove not in example_attackgraph.nodes
+    assert node_to_remove not in example_attackgraph.nodes.values()
 
     # Make sure it was correctly removed from parent and children references
     for parent in parents:
@@ -452,7 +453,7 @@ def test_attackgraph_deepcopy(example_attackgraph: AttackGraph):
     assert len(copied_attackgraph.nodes) \
         == len(example_attackgraph.nodes)
 
-    for node in copied_attackgraph.nodes:
+    for node in copied_attackgraph.nodes.values():
         assert node.id is not None
         original_node = example_attackgraph.get_node_by_id(node.id)
 
@@ -470,7 +471,7 @@ def test_attackgraph_deepcopy(example_attackgraph: AttackGraph):
             original_node.compromised_by
 
     # Make sure parents and children are same as those in the copied attack graph
-    for node in copied_attackgraph.nodes:
+    for node in copied_attackgraph.nodes.values():
         for parent in node.parents:
             assert parent.id is not None
             attack_graph_parent = copied_attackgraph.get_node_by_id(parent.id)

--- a/tests/attackgraph/test_attackgraph.py
+++ b/tests/attackgraph/test_attackgraph.py
@@ -210,7 +210,7 @@ def attackgraph_save_and_load_json_yml_model_given(
             # Make sure node was added to lookup dict with correct id / name
             assert node.id is not None
             assert loaded_attackgraph.nodes[node.id] == node
-            assert loaded_attackgraph.get_node_by_full_name(node.full_name) == node
+            assert loaded_attackgraph.nodes.fetch("full_name", node.full_name) == node
 
         for loaded_attacker in loaded_attackgraph.attackers:
             if not isinstance(loaded_attacker.id, int):
@@ -243,10 +243,10 @@ def test_attackgraph_save_and_load_json_yml_model_given_with_attackers(
 def test_attackgraph_attach_attackers(example_attackgraph: AttackGraph):
     """Make sure attackers are properly attached to graph"""
 
-    app1_ncu = example_attackgraph.get_node_by_full_name(
+    app1_ncu = example_attackgraph.nodes.fetch("full_name",
         'Application 1:networkConnectUninspected'
     )
-    app1_auv = example_attackgraph.get_node_by_full_name(
+    app1_auv = example_attackgraph.nodes.fetch("full_name",
         'Application 1:attemptUseVulnerability'
     )
 
@@ -584,17 +584,17 @@ def test_attackgraph_subtype():
         lang_graph=test_lang_graph,
         model=test_model
     )
-    ba_1_base_step1 = example_testlang_attackgraph.get_node_by_full_name(
+    ba_1_base_step1 = example_testlang_attackgraph.nodes.fetch("full_name",
         'BaseAsset 1:base_step1')
-    ba_1_base_step2 = example_testlang_attackgraph.get_node_by_full_name(
+    ba_1_base_step2 = example_testlang_attackgraph.nodes.fetch("full_name",
         'BaseAsset 1:base_step2')
-    sa_1_base_step1 = example_testlang_attackgraph.get_node_by_full_name(
+    sa_1_base_step1 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SubAsset 1:base_step1')
-    sa_1_base_step2 = example_testlang_attackgraph.get_node_by_full_name(
+    sa_1_base_step2 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SubAsset 1:base_step2')
-    sa_1_subasset_step1 = example_testlang_attackgraph.get_node_by_full_name(
+    sa_1_subasset_step1 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SubAsset 1:subasset_step1')
-    oa_1_other_step1 = example_testlang_attackgraph.get_node_by_full_name(
+    oa_1_other_step1 = example_testlang_attackgraph.nodes.fetch("full_name",
         'OtherAsset 1:other_step1')
 
     assert ba_1_base_step1 in oa_1_other_step1.children
@@ -654,25 +654,25 @@ def test_attackgraph_setops():
         model=test_model
     )
 
-    assetA1_opsA = example_testlang_attackgraph.get_node_by_full_name(
+    assetA1_opsA = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetA 1:testStepSetOpsA')
-    assetB1_opsB1 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB1_opsB1 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 1:testStepSetOpsB1')
-    assetB1_opsB2 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB1_opsB2 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 1:testStepSetOpsB2')
-    assetB1_opsB3 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB1_opsB3 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 1:testStepSetOpsB3')
-    assetB2_opsB1 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB2_opsB1 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 2:testStepSetOpsB1')
-    assetB2_opsB2 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB2_opsB2 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 2:testStepSetOpsB2')
-    assetB2_opsB3 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB2_opsB3 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 2:testStepSetOpsB3')
-    assetB3_opsB1 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB3_opsB1 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 3:testStepSetOpsB1')
-    assetB3_opsB2 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB3_opsB2 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 3:testStepSetOpsB2')
-    assetB3_opsB3 = example_testlang_attackgraph.get_node_by_full_name(
+    assetB3_opsB3 = example_testlang_attackgraph.nodes.fetch("full_name",
         'SetOpsAssetB 3:testStepSetOpsB3')
 
     assert assetB1_opsB1 in assetA1_opsA.children

--- a/tests/attackgraph/test_attackgraph.py
+++ b/tests/attackgraph/test_attackgraph.py
@@ -429,14 +429,8 @@ def test_attackgraph_deepcopy(example_attackgraph: AttackGraph):
 
     assert len(copied_attackgraph.nodes) == len(example_attackgraph.nodes)
 
-    assert list(copied_attackgraph._id_to_node.keys()) \
-        == list(example_attackgraph._id_to_node.keys())
-
     assert list(copied_attackgraph._id_to_attacker.keys()) \
         == list(example_attackgraph._id_to_attacker.keys())
-
-    assert list(copied_attackgraph._full_name_to_node.keys()) \
-        == list(example_attackgraph._full_name_to_node.keys())
 
     assert id(copied_attackgraph.model) == id(example_attackgraph.model)
 

--- a/tests/attackgraph/test_attackgraph.py
+++ b/tests/attackgraph/test_attackgraph.py
@@ -99,9 +99,9 @@ def attackgraph_save_load_no_model_given(
     # Load the attack graph
     loaded_attack_graph = AttackGraph.load_from_file(example_graph_path)
     assert node_with_reward_before.id is not None
-    node_with_reward_after = loaded_attack_graph.get_node_by_id(
+    node_with_reward_after = loaded_attack_graph.nodes[
         node_with_reward_before.id
-    )
+    ]
     assert node_with_reward_after is not None
     assert node_with_reward_after.extras.get('reward') == reward
 
@@ -115,7 +115,7 @@ def attackgraph_save_load_no_model_given(
     for loaded_node in loaded_attack_graph.nodes.values():
         if not isinstance(loaded_node.id, int):
             raise ValueError(f'Invalid node id for loaded node.')
-        original_node = example_attackgraph.get_node_by_id(loaded_node.id)
+        original_node = example_attackgraph.nodes[loaded_node.id]
 
         assert original_node, \
             f'Failed to find original node for id {loaded_node.id}.'
@@ -124,13 +124,13 @@ def attackgraph_save_load_no_model_given(
         loaded_node_dict = loaded_node.to_dict()
         original_node_dict = original_node.to_dict()
         for child in original_node_dict['children']:
-            child_node = example_attackgraph.get_node_by_id(child)
+            child_node = example_attackgraph.nodes[child]
             assert child_node, \
                 f'Failed to find child node for id {child}.'
             original_node_dict['children'][child] = str(child_node.id) + \
                 ":" + child_node.name
         for parent in original_node_dict['parents']:
-            parent_node = example_attackgraph.get_node_by_id(parent)
+            parent_node = example_attackgraph.nodes[parent]
             assert parent_node, \
                 f'Failed to find parent node for id {parent}.'
             original_node_dict['parents'][parent] = str(parent_node.id) + \
@@ -209,7 +209,7 @@ def attackgraph_save_and_load_json_yml_model_given(
 
             # Make sure node was added to lookup dict with correct id / name
             assert node.id is not None
-            assert loaded_attackgraph.get_node_by_id(node.id) == node
+            assert loaded_attackgraph.nodes[node.id] == node
             assert loaded_attackgraph.get_node_by_full_name(node.full_name) == node
 
         for loaded_attacker in loaded_attackgraph.attackers:
@@ -239,16 +239,6 @@ def test_attackgraph_save_and_load_json_yml_model_given_with_attackers(
             example_attackgraph,
             True
         )
-
-def test_attackgraph_get_node_by_id(example_attackgraph: AttackGraph):
-    """Make sure get_node_by_id works as intended"""
-    assert len(example_attackgraph.nodes)  # make sure loop is run
-    for node in example_attackgraph.nodes.values():
-        if not isinstance(node.id, int):
-            raise ValueError(f'Invalid node id.')
-        get_node = example_attackgraph.get_node_by_id(node.id)
-        assert get_node == node
-
 
 def test_attackgraph_attach_attackers(example_attackgraph: AttackGraph):
     """Make sure attackers are properly attached to graph"""
@@ -455,7 +445,7 @@ def test_attackgraph_deepcopy(example_attackgraph: AttackGraph):
 
     for node in copied_attackgraph.nodes.values():
         assert node.id is not None
-        original_node = example_attackgraph.get_node_by_id(node.id)
+        original_node = example_attackgraph.nodes[node.id]
 
         assert original_node
         assert id(original_node) != id(node)
@@ -463,7 +453,7 @@ def test_attackgraph_deepcopy(example_attackgraph: AttackGraph):
         assert id(original_node.asset) == id(node.asset)
 
         # Make sure thes node in the copied attack graph are the same
-        same_node = copied_attackgraph.get_node_by_id(node.id)
+        same_node = copied_attackgraph.nodes[node.id]
         assert id(same_node) == id(node)
 
         for attacker in node.compromised_by:
@@ -474,11 +464,11 @@ def test_attackgraph_deepcopy(example_attackgraph: AttackGraph):
     for node in copied_attackgraph.nodes.values():
         for parent in node.parents:
             assert parent.id is not None
-            attack_graph_parent = copied_attackgraph.get_node_by_id(parent.id)
+            attack_graph_parent = copied_attackgraph.nodes[parent.id]
             assert id(attack_graph_parent) == id(parent)
         for child in node.children:
             assert child.id is not None
-            attack_graph_child = copied_attackgraph.get_node_by_id(child.id)
+            attack_graph_child = copied_attackgraph.nodes[child.id]
             assert id(attack_graph_child) == id(child)
 
     assert len(copied_attackgraph.attackers) \
@@ -490,7 +480,7 @@ def test_attackgraph_deepcopy(example_attackgraph: AttackGraph):
 
         for entry_point in attacker.entry_points:
             assert entry_point.id
-            entry_point_in_attack_graph = copied_attackgraph.get_node_by_id(entry_point.id)
+            entry_point_in_attack_graph = copied_attackgraph.nodes[entry_point.id]
             assert entry_point_in_attack_graph
             assert entry_point == entry_point_in_attack_graph
             assert id(entry_point) == id(entry_point_in_attack_graph)
@@ -511,13 +501,13 @@ def test_attackgraph_deepcopy_attackers(example_attackgraph: AttackGraph):
     original_attacker = example_attackgraph.attackers[0]
     for reached in original_attacker.reached_attack_steps:
         assert reached.id
-        node = example_attackgraph.get_node_by_id(reached.id)
+        node = example_attackgraph.nodes[reached.id]
         assert node
         assert id(node) == id(reached)
 
     for entrypoint in original_attacker.entry_points:
         assert entrypoint.id
-        node = example_attackgraph.get_node_by_id(entrypoint.id)
+        node = example_attackgraph.nodes[entrypoint.id]
         assert node
         assert id(node) == id(entrypoint)
 
@@ -525,13 +515,13 @@ def test_attackgraph_deepcopy_attackers(example_attackgraph: AttackGraph):
     copied_attacker = copied_attackgraph.attackers[0]
     for reached in copied_attacker.reached_attack_steps:
         assert reached.id
-        node = copied_attackgraph.get_node_by_id(reached.id)
+        node = copied_attackgraph.nodes[reached.id]
         assert node
         assert id(node) == id(reached)
 
     for entrypoint in copied_attacker.entry_points:
         assert entrypoint.id
-        node = copied_attackgraph.get_node_by_id(entrypoint.id)
+        node = copied_attackgraph.nodes[entrypoint.id]
         assert node
         assert id(node) == id(entrypoint)
 


### PR DESCRIPTION
In various places, we have a list of items in the form of a dict for faster lookup. Still, it is often the case that we want to lookup items in the list (dict.values() actually) based on an attribute other than the one used as the dict keys. This PR introduces the LookupDict and in the future it will replace such simple dicts (such as attackgraph.nodes) with LookupDicts. LookupDicts work:

```
# like typical dicts
attackgraph.nodes['Network:attach']

# can filter based on  any attribute
attackgraph.nodes.lookup("id", 0)

# more complex filtering
attackgraph.nodes.lookup("id", [0,1,2], "in")
attackgraph.assets.lookup("name", "comprom", "contains")