### PR TITLE
Ensure that the important classes in Attack Graph, Language Graph, and Model modules have hash and repr methods.

### DIFF
--- a/maltoolbox/attackgraph/attacker.py
+++ b/maltoolbox/attackgraph/attacker.py
@@ -3,7 +3,6 @@ MAL-Toolbox Attack Graph Attacker Class
 """
 
 from __future__ import annotations
-from dataclasses import dataclass, field
 import copy
 import logging
 
@@ -46,7 +45,8 @@ class Attacker:
         return attacker_dict
 
     def __repr__(self) -> str:
-        return str(self.to_dict())
+        return 'Attacker(name: "%s", id: %d)' % (
+            self.name, self.id if self.id is not None else -1)
 
     def __deepcopy__(self, memo) -> Attacker:
         """Deep copy an Attacker"""

--- a/maltoolbox/attackgraph/attacker.py
+++ b/maltoolbox/attackgraph/attacker.py
@@ -14,13 +14,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-@dataclass
 class Attacker:
-    name: str
-    entry_points: list[AttackGraphNode] = field(default_factory=list)
-    reached_attack_steps: list[AttackGraphNode] = \
-        field(default_factory=list)
-    id: Optional[int] = None
+
+    def __init__(
+        self,
+        name: str,
+        entry_points: set[AttackGraphNode],
+        reached_attack_steps: set[AttackGraphNode],
+        attacker_id: Optional[int] = None
+    ):
+        self.name = name
+        self.entry_points = entry_points
+        self.reached_attack_steps = reached_attack_steps
+        self.id = attacker_id
 
     def to_dict(self) -> dict:
         attacker_dict: dict = {
@@ -50,8 +56,10 @@ class Attacker:
             return memo[id(self)]
 
         copied_attacker = Attacker(
-            id = self.id,
             name = self.name,
+            attacker_id = self.id,
+            entry_points = set(),
+            reached_attack_steps = set()
         )
 
         # Remember that self was already copied
@@ -90,8 +98,8 @@ class Attacker:
             )
             return
 
-        node.compromised_by.append(self)
-        self.reached_attack_steps.append(node)
+        node.compromised_by.add(self)
+        self.reached_attack_steps.add(node)
 
     def undo_compromise(self, node: AttackGraphNode) -> None:
         """

--- a/maltoolbox/attackgraph/attackgraph.py
+++ b/maltoolbox/attackgraph/attackgraph.py
@@ -98,7 +98,8 @@ class AttackGraph():
             self._generate_graph()
 
     def __repr__(self) -> str:
-        return f'AttackGraph({len(self.nodes)} nodes)'
+        return 'AttackGraph(Number of nodes: %d, model: %s, language: %s)' % (
+            len(self.nodes), self.model, self.lang_graph)
 
     def _to_dict(self) -> dict:
         """Convert AttackGraph to dict"""

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from typing import Any, Optional
     from . import Attacker
     from ..language import LanguageGraphAttackStep, Detector
+    from ..model import ModelAsset
 
 class AttackGraphNode:
     """Node part of AttackGraph"""
@@ -31,14 +32,14 @@ class AttackGraphNode:
         self.id = node_id
         self.model_asset = model_asset
 
-        self.defense_status = None
-        self.existence_status = None
-        self.children = set()
-        self.parents = set()
+        self.defense_status: Optional[float] = None
+        self.existence_status: Optional[bool] = None
+        self.children: set[AttackGraphNode] = set()
+        self.parents: set[AttackGraphNode] = set()
         self.is_viable: bool = True
         self.is_necessary: bool = True
-        self.compromised_by = []
-        self.extras = {}
+        self.compromised_by: set[Attacker] = set()
+        self.extras: dict = {}
 
     def to_dict(self) -> dict:
         """Convert node to dictionary"""
@@ -195,4 +196,4 @@ class AttackGraphNode:
 
     @cached_property
     def info(self) -> dict[str, str]:
-        return self.lang_graph_attack_step.info
+        return self.lg_attack_step.info

--- a/maltoolbox/attackgraph/node.py
+++ b/maltoolbox/attackgraph/node.py
@@ -78,7 +78,8 @@ class AttackGraphNode:
 
 
     def __repr__(self) -> str:
-        return '%s(id:%d, type:%s)' % (self.full_name, self.id, self.type)
+        return 'AttackGraphNode(name: "%s", id: %d, type: %s)' % (
+            self.full_name, self.id, self.type)
 
 
     def __deepcopy__(self, memo) -> AttackGraphNode:

--- a/maltoolbox/language/languagegraph.py
+++ b/maltoolbox/language/languagegraph.py
@@ -61,6 +61,7 @@ class Context(dict):
     def __str__(self) -> str:
         return str({label: asset.name for label, asset in self._context_dict.items()})
 
+
 @dataclass
 class LanguageGraphAsset:
     name: str
@@ -104,7 +105,7 @@ class LanguageGraphAsset:
 
 
     def __repr__(self) -> str:
-        return str(self.to_dict())
+        return 'LanguageGraphAsset(name: "%s")' % self.name
 
 
     def __hash__(self):
@@ -274,7 +275,9 @@ class LanguageGraphAssociation:
 
 
     def __repr__(self) -> str:
-        return str(self.to_dict())
+        return ('LanguageGraphAssociation(name: "%s", '
+            'left_field: %s, right_field: %s)' %
+            (self.name, self.left_field, self.right_field))
 
 
     @property
@@ -658,6 +661,13 @@ class LanguageGraph():
             self._generate_graph()
 
 
+    def __repr__(self) -> str:
+        return 'LanguageGraph(id: "%s", version: "%s")' % (
+            self.metadata.get('id', 'N/A'),
+            self.metadata.get('version', 'N/A')
+        )
+
+
     @classmethod
     def from_mal_spec(cls, mal_spec_file: str) -> LanguageGraph:
         """
@@ -692,7 +702,7 @@ class LanguageGraph():
             'Serializing %s assets.', len(self.assets.items())
         )
 
-        serialized_graph = {}
+        serialized_graph = {'metadata': self.metadata}
         for asset in self.assets.values():
             serialized_graph[asset.name] = asset.to_dict()
 
@@ -719,6 +729,8 @@ class LanguageGraph():
 
         logger.debug('Create language graph from dictionary.')
         lang_graph = LanguageGraph()
+        lang_graph.metadata = serialized_graph.pop('metadata')
+
         # Recreate all of the assets
         for asset_dict in serialized_graph.values():
             logger.debug(

--- a/maltoolbox/model.py
+++ b/maltoolbox/model.py
@@ -135,7 +135,8 @@ class Model():
     next_id: int = 0
 
     def __repr__(self) -> str:
-        return f'Model {self.name}'
+        return 'Model(name: "%s", language: %s)' % (
+            self.name, self.lang_graph)
 
 
     def __init__(
@@ -577,7 +578,8 @@ class ModelAsset:
 
 
     def __repr__(self):
-        return self.name
+        return 'ModelAsset(name: "%s", id: %d, type: %s)' % (
+            self.name, self.id, self.type)
 
 
     def validate_associated_assets(

--- a/tests/attackgraph/test_analyzer.py
+++ b/tests/attackgraph/test_analyzer.py
@@ -1,7 +1,9 @@
 """Tests for analyzers"""
 
 from maltoolbox.attackgraph import AttackGraphNode
+from maltoolbox.attackgraph.attackgraph import AttackGraph
 from maltoolbox.attackgraph.analyzers.apriori import propagate_viability_from_unviable_node
+from maltoolbox.language import LanguageGraph
 
 # Apriori analyzer
 # TODO: Add apriori analyzer test implementations
@@ -35,7 +37,7 @@ def test_analyzers_apriori_calculate_viability_and_necessity():
 def test_analyzers_apriori_prune_unviable_and_unnecessary_nodes():
     pass
 
-def test_analyzers_apriori_propagate_viability_from_unviable_node():
+def test_analyzers_apriori_propagate_viability_from_unviable_node(dummy_lang_graph: LanguageGraph):
     r"""Create a graph from nodes
 
             node1
@@ -45,45 +47,31 @@ def test_analyzers_apriori_propagate_viability_from_unviable_node():
     node4  node5    node6
     """
 
-    # Create a graph of nodes according to above diagram
-    node1 = AttackGraphNode(
-        type = "defense",
-        name = "node1",
-        lang_graph_attack_step = None,
-    )
-    node2 = AttackGraphNode(
-        type = "or",
-        name = "node2",
-        lang_graph_attack_step = None,
-    )
-    node3 = AttackGraphNode(
-        type = "or",
-        name = "node3",
-        lang_graph_attack_step = None,
-        defense_status=0.0
-    )
-    node4 = AttackGraphNode(
-        type = "or",
-        name = "node4",
-        lang_graph_attack_step = None,
-    )
-    node5 = AttackGraphNode(
-        type = "or",
-        name = "node5",
-        lang_graph_attack_step = None,
-    )
-    node6 = AttackGraphNode(
-        type = "or",
-        name = "node6",
-        lang_graph_attack_step = None,
-    )
+    dummy_or_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyOrAttackStep']
+    dummy_defense_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyDefenseAttackStep']
+    attack_graph = AttackGraph(dummy_lang_graph)
 
-    node1.id = 1
-    node2.id = 2
-    node3.id = 3
-    node4.id = 4
-    node5.id = 5
-    node6.id = 6
+    # Create a graph of nodes according to above diagram
+    node1 = attack_graph.add_node(
+        lg_attack_step = dummy_defense_attack_step
+    )
+    node2 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
+    )
+    node3 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
+    )
+    node4 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
+    )
+    node5 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
+    )
+    node6 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
+    )
 
     node1.children = [node2, node3]
     node2.children = [node4, node5]

--- a/tests/attackgraph/test_analyzer.py
+++ b/tests/attackgraph/test_analyzer.py
@@ -73,20 +73,20 @@ def test_analyzers_apriori_propagate_viability_from_unviable_node(dummy_lang_gra
         lg_attack_step = dummy_or_attack_step
     )
 
-    node1.children = [node2, node3]
-    node2.children = [node4, node5]
-    node3.children = [node5, node6]
+    node1.children = {node2, node3}
+    node2.children = {node4, node5}
+    node3.children = {node5, node6}
 
-    node2.parents = [node1]
-    node4.parents = [node2]
-    node5.parents = [node2, node3]
-    node6.parents = [node3]
+    node2.parents = {node1}
+    node4.parents = {node2}
+    node5.parents = {node2, node3}
+    node6.parents = {node3}
 
     node1.defense_status = 1.0
     node1.is_viable = False
     unviable_nodes = propagate_viability_from_unviable_node(node1)
     unviable_node_names = {node.name for node in unviable_nodes}
-    expected_unviable_node_names = set(
-        [node2.name, node3.name, node4.name, node5.name, node6.name]
-    )
+    expected_unviable_node_names = {
+        node2.name, node3.name, node4.name, node5.name, node6.name
+    }
     assert unviable_node_names == expected_unviable_node_names

--- a/tests/attackgraph/test_attacker.py
+++ b/tests/attackgraph/test_attacker.py
@@ -8,13 +8,12 @@ from maltoolbox.language import LanguageGraph
 def test_attacker_to_dict(dummy_lang_graph: LanguageGraph):
     """Test Attacker to dict conversion"""
 
-    dummy_attack_step = dummy_lang_graph.assets['DummyAsset'].\
-        attack_steps['DummyAttackStep']
+    dummy_or_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyOrAttackStep']
+    attack_graph = AttackGraph(dummy_lang_graph)
 
-    node1 = AttackGraphNode(
-        type = "or",
-        name = "node1",
-        lang_graph_attack_step = dummy_attack_step,
+    node1 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
     )
     attacker = Attacker("Test Attacker", [], [node1])
     assert attacker.to_dict() == {
@@ -29,18 +28,16 @@ def test_attacker_to_dict(dummy_lang_graph: LanguageGraph):
 def test_attacker_compromise(dummy_lang_graph: LanguageGraph):
     """Attack a node and see expected behavior"""
 
-    dummy_attack_step = dummy_lang_graph.assets['DummyAsset'].\
-        attack_steps['DummyAttackStep']
+    dummy_or_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyOrAttackStep']
+    attack_graph = AttackGraph(dummy_lang_graph)
 
-    node1 = AttackGraphNode(
-        type = "or",
-        name = "node1",
-        lang_graph_attack_step = dummy_attack_step,
+    node1 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
     )
     attacker = Attacker("Test Attacker", [], [])
     assert not attacker.entry_points
     attack_graph = AttackGraph(dummy_lang_graph)
-    attack_graph.add_node(node1)
     attack_graph.add_attacker(attacker)
 
     attacker.compromise(node1)
@@ -56,17 +53,15 @@ def test_attacker_compromise(dummy_lang_graph: LanguageGraph):
 def test_attacker_undo_compromise(dummy_lang_graph: LanguageGraph):
     """Make sure undo compromise removes attacker/node"""
 
-    dummy_attack_step = dummy_lang_graph.assets['DummyAsset'].\
-        attack_steps['DummyAttackStep']
+    dummy_or_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyOrAttackStep']
+    attack_graph = AttackGraph(dummy_lang_graph)
 
-    node1 = AttackGraphNode(
-        type = "or",
-        name = "node1",
-        lang_graph_attack_step = dummy_attack_step,
+    node1 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
     )
     attacker = Attacker("attacker1", [], [])
     attack_graph = AttackGraph(dummy_lang_graph)
-    attack_graph.add_node(node1)
     attack_graph.add_attacker(attacker)
 
     attacker.compromise(node1)

--- a/tests/attackgraph/test_attacker.py
+++ b/tests/attackgraph/test_attacker.py
@@ -15,7 +15,7 @@ def test_attacker_to_dict(dummy_lang_graph: LanguageGraph):
     node1 = attack_graph.add_node(
         lg_attack_step = dummy_or_attack_step
     )
-    attacker = Attacker("Test Attacker", [], [node1])
+    attacker = Attacker("Test Attacker", set(), {node1})
     assert attacker.to_dict() == {
         "id": None,
         "name": "Test Attacker",
@@ -35,20 +35,20 @@ def test_attacker_compromise(dummy_lang_graph: LanguageGraph):
     node1 = attack_graph.add_node(
         lg_attack_step = dummy_or_attack_step
     )
-    attacker = Attacker("Test Attacker", [], [])
+    attacker = Attacker("Test Attacker", set(), set())
     assert not attacker.entry_points
     attack_graph = AttackGraph(dummy_lang_graph)
     attack_graph.add_attacker(attacker)
 
     attacker.compromise(node1)
-    assert attacker.reached_attack_steps == [node1]
+    assert attacker.reached_attack_steps == {node1}
     assert not attacker.entry_points
 
-    assert node1.compromised_by == [attacker]
+    assert node1.compromised_by == {attacker}
 
     attacker.compromise(node1) # Compromise same node again not a problem
-    assert attacker.reached_attack_steps == [node1]
-    assert node1.compromised_by == [attacker]
+    assert attacker.reached_attack_steps == {node1}
+    assert node1.compromised_by == {attacker}
 
 def test_attacker_undo_compromise(dummy_lang_graph: LanguageGraph):
     """Make sure undo compromise removes attacker/node"""
@@ -60,18 +60,18 @@ def test_attacker_undo_compromise(dummy_lang_graph: LanguageGraph):
     node1 = attack_graph.add_node(
         lg_attack_step = dummy_or_attack_step
     )
-    attacker = Attacker("attacker1", [], [])
+    attacker = Attacker("attacker1", set(), set())
     attack_graph = AttackGraph(dummy_lang_graph)
     attack_graph.add_attacker(attacker)
 
     attacker.compromise(node1)
-    assert attacker.reached_attack_steps == [node1]
-    assert node1.compromised_by == [attacker]
+    assert attacker.reached_attack_steps == {node1}
+    assert node1.compromised_by == {attacker}
     attacker.compromise(node1) # Compromise same node again not a problem
-    assert attacker.reached_attack_steps == [node1]
-    assert node1.compromised_by == [attacker]
+    assert attacker.reached_attack_steps == {node1}
+    assert node1.compromised_by == {attacker}
 
     attacker.undo_compromise(node1)
     # Make sure attacker/node  was removed
-    assert attacker.reached_attack_steps == []
-    assert node1.compromised_by == []
+    assert attacker.reached_attack_steps == set()
+    assert node1.compromised_by == set()

--- a/tests/attackgraph/test_node.py
+++ b/tests/attackgraph/test_node.py
@@ -15,41 +15,34 @@ def test_attackgraphnode(dummy_lang_graph: LanguageGraph):
     node4  node5    node6
     """
 
-    dummy_attack_step = dummy_lang_graph.assets['DummyAsset'].\
-        attack_steps['DummyAttackStep']
+    dummy_or_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyOrAttackStep']
+    dummy_and_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyAndAttackStep']
+    dummy_defense_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyDefenseAttackStep']
+    attack_graph = AttackGraph(dummy_lang_graph)
 
     # Create a graph of nodes according to above diagram
-    node1 = AttackGraphNode(
-        type = "or",
-        name = "node1",
-        lang_graph_attack_step = dummy_attack_step,
+    node1 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
     )
-    node2 = AttackGraphNode(
-        type = "defense",
-        name = "node2",
-        lang_graph_attack_step = dummy_attack_step,
-        defense_status=1.0
+    node2 = attack_graph.add_node(
+        lg_attack_step = dummy_defense_attack_step
     )
-    node3 = AttackGraphNode(
-        type = "defense",
-        name = "node3",
-        lang_graph_attack_step = dummy_attack_step,
-        defense_status=0.0
+    node2.defense_status = 1.0
+    node3 = attack_graph.add_node(
+        lg_attack_step = dummy_defense_attack_step
     )
-    node4 = AttackGraphNode(
-        type = "or",
-        name = "node4",
-        lang_graph_attack_step = dummy_attack_step,
+    node3.defense_status = 0.0
+    node4 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
     )
-    node5 = AttackGraphNode(
-        type = "and",
-        name = "node5",
-        lang_graph_attack_step = dummy_attack_step,
+    node5 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
     )
-    node6 = AttackGraphNode(
-        type = "or",
-        name = "node6",
-        lang_graph_attack_step = dummy_attack_step,
+    node6 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
     )
 
     node1.children = [node2, node3]
@@ -68,13 +61,6 @@ def test_attackgraphnode(dummy_lang_graph: LanguageGraph):
         reached_attack_steps = []
     )
 
-    attack_graph = AttackGraph(dummy_lang_graph)
-    attack_graph.add_node(node1)
-    attack_graph.add_node(node2)
-    attack_graph.add_node(node3)
-    attack_graph.add_node(node4)
-    attack_graph.add_node(node5)
-    attack_graph.add_node(node6)
     attack_graph.add_attacker(attacker)
 
     node6.compromise(attacker)

--- a/tests/attackgraph/test_node.py
+++ b/tests/attackgraph/test_node.py
@@ -45,32 +45,32 @@ def test_attackgraphnode(dummy_lang_graph: LanguageGraph):
         lg_attack_step = dummy_or_attack_step
     )
 
-    node1.children = [node2, node3]
-    node2.children = [node4, node5]
-    node3.children = [node5, node6]
+    node1.children = {node2, node3}
+    node2.children = {node4, node5}
+    node3.children = {node5, node6}
 
-    node2.parents = [node1]
-    node4.parents = [node2]
-    node5.parents = [node2, node3]
-    node6.parents = [node3]
+    node2.parents = {node1}
+    node4.parents = {node2}
+    node5.parents = {node2, node3}
+    node6.parents = {node3}
 
     # Make sure compromised node has attacker added to it
     attacker = Attacker(
         name = "Test Attacker",
-        entry_points = [node1],
-        reached_attack_steps = []
+        entry_points = {node1},
+        reached_attack_steps = set()
     )
 
     attack_graph.add_attacker(attacker)
 
     node6.compromise(attacker)
-    assert node6.compromised_by == [attacker]
+    assert node6.compromised_by == {attacker}
     assert node6.is_compromised()
     assert node6.is_compromised_by(attacker)
 
     # Make sure uncompromise will remove the attacker
     node6.undo_compromise(attacker)
-    assert node6.compromised_by == []
+    assert node6.compromised_by == set()
     assert not node6.is_compromised()
 
     # Node 3 is disabled defense

--- a/tests/attackgraph/test_query.py
+++ b/tests/attackgraph/test_query.py
@@ -18,8 +18,8 @@ def test_query_is_node_traversable_by_attacker(dummy_lang_graph: LanguageGraph):
     # An attacker with no meaningful data
     attacker = Attacker(
         name = "Test Attacker",
-        entry_points = [],
-        reached_attack_steps = []
+        entry_points = set(),
+        reached_attack_steps = set()
     )
     attack_graph.add_attacker(attacker)
 
@@ -45,8 +45,8 @@ def test_query_is_node_traversable_by_attacker(dummy_lang_graph: LanguageGraph):
     node4 = attack_graph.add_node(
         lg_attack_step = dummy_and_attack_step
     )
-    node4.parents = [node2, node3]
-    node2.children = [node4]
-    node3.children = [node4]
+    node4.parents = {node2, node3}
+    node2.children = {node4}
+    node3.children = {node4}
     traversable = is_node_traversable_by_attacker(node4, attacker)
     assert not traversable

--- a/tests/attackgraph/test_query.py
+++ b/tests/attackgraph/test_query.py
@@ -9,8 +9,11 @@ from maltoolbox.attackgraph.query import (
 def test_query_is_node_traversable_by_attacker(dummy_lang_graph: LanguageGraph):
     """Make sure it returns True or False when expected"""
 
-    dummy_attack_step = dummy_lang_graph.assets['DummyAsset'].\
-        attack_steps['DummyAttackStep']
+    dummy_or_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyOrAttackStep']
+    dummy_and_attack_step = dummy_lang_graph.assets['DummyAsset'].\
+        attack_steps['DummyAndAttackStep']
+    attack_graph = AttackGraph(dummy_lang_graph)
 
     # An attacker with no meaningful data
     attacker = Attacker(
@@ -18,46 +21,32 @@ def test_query_is_node_traversable_by_attacker(dummy_lang_graph: LanguageGraph):
         entry_points = [],
         reached_attack_steps = []
     )
+    attack_graph.add_attacker(attacker)
 
     # Node1 should be traversable since node type is OR
-    node1 = AttackGraphNode(
-        type = "or",
-        name = "node1",
-        lang_graph_attack_step = dummy_attack_step,
+    node1 = attack_graph.add_node(
+        lg_attack_step = dummy_or_attack_step
     )
-
-    attack_graph = AttackGraph(dummy_lang_graph)
-    attack_graph.add_node(node1)
-    attack_graph.add_attacker(attacker)
     traversable = is_node_traversable_by_attacker(node1, attacker)
     assert traversable
 
     # Node2 should be traversable since node has no parents
-    node2 = AttackGraphNode(
-        type = "and",
-        name = "node2",
-        lang_graph_attack_step = dummy_attack_step,
+    node2 = attack_graph.add_node(
+        lg_attack_step = dummy_and_attack_step
     )
-    attack_graph.add_node(node2)
     traversable = is_node_traversable_by_attacker(node2, attacker)
     assert traversable
 
     # Node 4 should not be traversable since node has type AND
     # and it has two parents that are not compromised by attacker
-    node3 = AttackGraphNode(
-        type = "and",
-        name = "node3",
-        lang_graph_attack_step = dummy_attack_step,
+    node3 = attack_graph.add_node(
+        lg_attack_step = dummy_and_attack_step
     )
-    node4 = AttackGraphNode(
-        type = "and",
-        name = "node4",
-        lang_graph_attack_step = dummy_attack_step,
+    node4 = attack_graph.add_node(
+        lg_attack_step = dummy_and_attack_step
     )
     node4.parents = [node2, node3]
     node2.children = [node4]
     node3.children = [node4]
-    attack_graph.add_node(node3)
-    attack_graph.add_node(node4)
     traversable = is_node_traversable_by_attacker(node4, attacker)
     assert not traversable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,12 +56,27 @@ def dummy_lang_graph(corelang_lang_graph):
         name = 'DummyAsset'
     )
     lang_graph.assets['DummyAsset'] = dummy_asset
-    dummy_attack_step_node = LanguageGraphAttackStep(
-        name = 'DummyAttackStep',
+    dummy_or_attack_step_node = LanguageGraphAttackStep(
+        name = 'DummyOrAttackStep',
         type = 'or',
         asset = dummy_asset
     )
-    dummy_asset.attack_steps['DummyAttackStep'] = dummy_attack_step_node
+    dummy_asset.attack_steps['DummyOrAttackStep'] = dummy_or_attack_step_node
 
+    dummy_and_attack_step_node = LanguageGraphAttackStep(
+        name = 'DummyAndAttackStep',
+        type = 'and',
+        asset = dummy_asset
+    )
+    dummy_asset.attack_steps['DummyAndAttackStep'] =\
+        dummy_and_attack_step_node
+
+    dummy_defense_attack_step_node = LanguageGraphAttackStep(
+        name = 'DummyDefenseAttackStep',
+        type = 'defense',
+        asset = dummy_asset
+    )
+    dummy_asset.attack_steps['DummyDefenseAttackStep'] =\
+        dummy_defense_attack_step_node
 
     return lang_graph


### PR DESCRIPTION
This PR removes the dataclass decorator from two important classes `AttackGraphNode` and `Attacker`.

Another major change is that the `AttackGraphNode` class now requires the id, it is no longer optional. Which in turn means that `AttackGraphNodes` are now created as they are added to the `AttackGraph`, analogously to how the `ModelAssets` are created as they are added to a `Model`.