### PR TITLE
Langgraph walkthrough - typehinting, docstringing and simplifications

### DIFF
--- a/maltoolbox/language/languagegraph.py
+++ b/maltoolbox/language/languagegraph.py
@@ -49,7 +49,7 @@ class Detector:
 
 
 class Context(dict):
-    """TODO: What is a context?"""
+    """Context is part of detectors to provide meta data about attackers"""
     def __init__(self, context) -> None:
         super().__init__(context)
         self._context_dict = context
@@ -222,6 +222,7 @@ class LanguageGraphAsset:
 
 @dataclass
 class LanguageGraphAssociationField:
+    """A field in an association"""
     asset: LanguageGraphAsset
     fieldname: str
     minimum: int


### PR DESCRIPTION
This is me walking through the Language Graph and changing things the linter tells me about and adding typehints.

I also added/altered docstrings and made some simplifications of small parts of the code.

I added a couple of TODO comments I want to fix before this merge, mostly for docstrings and 'type errors'.

Some mypy is failing now because I added typehinting and we need to abide by those, also TODO before merge.