### PR TITLE
feat: pickling support, remove explicit pickling methods

### DIFF
--- a/maltoolbox/language/languagegraph.py
+++ b/maltoolbox/language/languagegraph.py
@@ -80,7 +80,7 @@ class LanguageGraphAsset:
         field(default_factory=dict)
     info: dict = field(default_factory=dict)
     own_super_asset: LanguageGraphAsset | None = None
-    own_sub_assets: set[LanguageGraphAsset] = field(default_factory=set)
+    own_sub_assets: list[LanguageGraphAsset] = field(default_factory=list)
     own_variables: dict = field(default_factory=dict)
     is_abstract: bool | None = None
 
@@ -115,7 +115,7 @@ class LanguageGraphAsset:
         return f'LanguageGraphAsset(name: "{self.name}")'
 
     def __hash__(self):
-        return hash(self.name)
+        return id(self)
 
     def is_subasset_of(self, target_asset: LanguageGraphAsset) -> bool:
         """Check if an asset extends the target asset through inheritance.
@@ -383,7 +383,7 @@ class LanguageGraphAttackStep:
     detectors: dict = field(default_factory=dict)
 
     def __hash__(self):
-        return hash(self.full_name)
+        return id(self)
 
     @property
     def children(self) -> dict[
@@ -773,7 +773,7 @@ class LanguageGraph:
                 attack_steps={},
                 info=asset['info'],
                 own_super_asset=None,
-                own_sub_assets=set(),
+                own_sub_assets=list(),
                 own_variables={},
                 is_abstract=asset['is_abstract']
             )
@@ -788,7 +788,8 @@ class LanguageGraph:
                     msg = f'Super asset "{super_name}" for "{asset["name"]}" not found'
                     logger.error(msg)
                     raise LanguageGraphSuperAssetNotFoundError(msg)
-                super_asset.own_sub_assets.add(asset_node)
+
+                super_asset.own_sub_assets.append(asset_node)
                 asset_node.own_super_asset = super_asset
 
         # Associations
@@ -1454,7 +1455,7 @@ class LanguageGraph:
                     raise LanguageGraphSuperAssetNotFoundError(
                         msg % (asset_dict["superAsset"], asset_dict["name"]))
 
-                super_asset.own_sub_assets.add(asset)
+                super_asset.own_sub_assets.append(asset)
                 asset.own_super_asset = super_asset
 
     def _set_variables_for_assets(
@@ -1625,7 +1626,7 @@ class LanguageGraph:
                 attack_steps={},
                 info=asset_dict['meta'],
                 own_super_asset=None,
-                own_sub_assets=set(),
+                own_sub_assets=list(),
                 own_variables={},
                 is_abstract=asset_dict['isAbstract']
             )
@@ -1781,11 +1782,3 @@ class LanguageGraph:
         """
         self.assets = {}
         self._generate_graph()
-
-    def __getstate__(self):
-        return self._to_dict()
-
-    def __setstate__(self, state):
-        temp_lang_graph = self._from_dict(state)
-        self.assets = temp_lang_graph.assets
-        self.metadata = temp_lang_graph.metadata

--- a/maltoolbox/model.py
+++ b/maltoolbox/model.py
@@ -310,27 +310,6 @@ class Model:
                 "Try to upgrade it with 'maltoolbox upgrade-model'"
             ) from e
 
-    def __getstate__(self):
-        lang_state = self.lang_graph.__getstate__()
-        state = self._to_dict()
-        return {
-            'model_state': state,
-            'lang_graph': lang_state
-        }
-    
-    def __setstate__(self, state):
-        # Restore the language graph first
-        lang_graph = LanguageGraph.__new__(LanguageGraph)
-        lang_graph.__setstate__(state['lang_graph'])
-        self.lang_graph = lang_graph
-        
-        # Restore the model state by creating a temporary model and copying attributes
-        temp_model = self._from_dict(state['model_state'], self.lang_graph)
-        self.name = temp_model.name
-        self.assets = temp_model.assets
-        self._name_to_asset = temp_model._name_to_asset
-        self.maltoolbox_version = temp_model.maltoolbox_version
-        self.next_id = temp_model.next_id
 
 class ModelAsset:
     def __init__(

--- a/tests/language/test_languagegraph.py
+++ b/tests/language/test_languagegraph.py
@@ -228,13 +228,25 @@ def test_attack_step_types(corelang_lang_graph: LanguageGraph):
         assert attack_step.type in ["or", "and", "defense", "exist", "notExist"], (f"Attack step {attack_step.name} has type {attack_step.type}. "
             "Attack step types must be one of: or, and, defense, exist, notExist")
 
+
 def test_pickle_languagegraph(corelang_lang_graph: LanguageGraph):
     """Test that we can pickle and unpickle a language graph"""
-    pickle_path = "/tmp/languagegraph.pkl"
-    with open(pickle_path, "wb") as f:
-        pickle.dump(corelang_lang_graph, f)
-
-    with open(pickle_path, "rb") as f:
-        unpickled_lg: LanguageGraph = pickle.load(f)
-
+    pickled_lg = pickle.dumps(corelang_lang_graph)
+    unpickled_lg: LanguageGraph = pickle.loads(pickled_lg)
     assert corelang_lang_graph._to_dict() == unpickled_lg._to_dict()
+
+
+def test_pickle_languagegraph_asset(corelang_lang_graph: LanguageGraph):
+    """Test that we can pickle and unpickle a language graph asset"""
+    lang_graph_asset = corelang_lang_graph.assets['Application']
+    pickled_asset = pickle.dumps(lang_graph_asset)
+    unpickled_asset = pickle.loads(pickled_asset)
+    assert lang_graph_asset.to_dict() == unpickled_asset.to_dict()
+
+
+def test_pickle_languagegraph_attack_step(corelang_lang_graph: LanguageGraph):
+    """Test that we can pickle and unpickle a language graph attack step"""
+    lang_graph_step = corelang_lang_graph.assets['Application'].attack_steps['fullAccess']
+    pickled_step = pickle.dumps(lang_graph_step)
+    ununpickled_step = pickle.loads(pickled_step)
+    assert lang_graph_step.to_dict() == ununpickled_step.to_dict()


### PR DESCRIPTION
- the previous hash method crashed when unpickling lg attack step
- store lg assets in lists instead of sets in .own_sub_assets
- the explicit pickling methods was not needed