### PR TITLE
Move documentation to wiki and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ MAL ([Meta Attack Language](https://mal-lang.org/)) models and attack graphs.
 
 Attack graphs can be used to run simulations in [MAL Simulator](https://github.com/mal-lang/mal-simulator) or run your own custom analysis on.
 
-- [MAL Toolbox Documentation](https://mal-lang.org/mal-toolbox/index.html)
+- [MAL Toolbox Documentation](https://github.com/mal-lang/mal-toolbox/wiki)
 - [MAL Toolbox tutorial](https://github.com/mal-lang/mal-toolbox-tutorial)
-- [MAL Toolbox Wiki](https://github.com/mal-lang/mal-toolbox/wiki)
 
 # Usage
 


### PR DESCRIPTION
With this PR: 
- The documentation that was in https://mal-lang.org/mal-toolbox/ is now in the wiki.
- The README has been significantly shortened to avoid redundancy.