### PR TITLE
Standardize mal-lang download via git url

### DIFF
--- a/maltoolbox/language/languagegraph.py
+++ b/maltoolbox/language/languagegraph.py
@@ -477,8 +477,22 @@ def language_graph_from_git_url(git_url: str) -> LanguageGraph:
 
     # Download the repository to a local directory
     dir = download_git_repo(git_url)
-    main_mal_file = dir / 'src' / 'main' / 'mal' / 'main.mal'
-    return language_graph_from_mal_spec(str(main_mal_file))
+    mal_files = list(dir.rglob('*.mal'))
+
+    if not mal_files:
+        raise FileNotFoundError("Execution failed: No .mal files found in the cloned repository.")
+    
+    if len(mal_files) == 1:
+        mal_file = mal_files[0]
+    else:
+        main_mal_files = [f for f in mal_files if f.name == 'main.mal']
+        if main_mal_files:
+            mal_file = main_mal_files[0]
+        else:
+            raise ValueError("Execution failed: .mal files found but no main.mal file in the repository.")
+
+    
+    return language_graph_from_mal_spec(str(mal_file))
 
 
 def language_graph_from_mal_spec(mal_spec_file: str) -> LanguageGraph:

--- a/tests/language/test_languagegraph.py
+++ b/tests/language/test_languagegraph.py
@@ -305,14 +305,14 @@ def test_attack_graph_node_causal_mode(tmpdir):
 
 @pytest.mark.integration
 def test_load_from_git():
-    """Test that we can pickle and unpickle a language graph attack step"""
+    """Test that we can load the mal-lang through a git repo url"""
     git_url = 'git@github.com:mal-lang/coreLang.git'
     lang_graph = load_language_graph_from_file(git_url)
     assert lang_graph.assets, "Expected assets in the loaded language graph"
 
 @pytest.mark.integration
 def test_load_from_git_not_main_mal():
-    """Test that we can pickle and unpickle a language graph attack step"""
+    """Test that we can load the mal-lang from a git repo that has only one mal file and it is not called main.mal"""
     git_url = 'git@github.com:mal-lang/exampleLang.git'
     lang_graph = load_language_graph_from_file(git_url)
     assert lang_graph.assets, "Expected assets in the loaded language graph"

--- a/tests/language/test_languagegraph.py
+++ b/tests/language/test_languagegraph.py
@@ -309,3 +309,17 @@ def test_load_from_git():
     git_url = 'git@github.com:mal-lang/coreLang.git'
     lang_graph = load_language_graph_from_file(git_url)
     assert lang_graph.assets, "Expected assets in the loaded language graph"
+
+@pytest.mark.integration
+def test_load_from_git_not_main_mal():
+    """Test that we can pickle and unpickle a language graph attack step"""
+    git_url = 'git@github.com:mal-lang/exampleLang.git'
+    lang_graph = load_language_graph_from_file(git_url)
+    assert lang_graph.assets, "Expected assets in the loaded language graph"
+
+@pytest.mark.integration
+def test_load_from_git_no_mal_files():
+    """Test that a FileNotFoundError is raised when no .mal files exist in the repo."""
+    git_url = 'git@github.com:mal-lang/mal-specification.git'
+    with pytest.raises(FileNotFoundError, match="Execution failed: No .mal files found in the cloned repository."):
+        load_language_graph_from_file(git_url)


### PR DESCRIPTION
mal-toolbox currently looks for the file `main.mal` in the /src/main/mal subfolder. This PR fixes that and follows the approach proposed in #241.